### PR TITLE
refactor(r): split extract_city.r into reusable shape utils + thin script

### DIFF
--- a/R/result_analysis/Extraction_configs/Savannah_City_of_GA.r
+++ b/R/result_analysis/Extraction_configs/Savannah_City_of_GA.r
@@ -1,0 +1,9 @@
+######## Set constants########
+BLOCK_GEOMETRY_FILES <- "tl_2020_13051_tabblock20"
+BG_GEOMETRY_FILES <- "tl_2020_13051_bg20"
+LOCATION_BASE <- "Savannah_City_of_GA"
+LOCATION_SUP <- paste("Intersecting", LOCATION_BASE, sep = "_")
+LOCATION_SUB <- paste("Contained_in", LOCATION_BASE, sep = "_")
+CITY_LIMIT_FOLDER <- LOCATION_BASE
+CONTAINING_COUNTY <- "Chatham_County_GA"
+CITY_LIMIT_FILE <- "City_Limit"

--- a/R/result_analysis/utility_functions/extract_city.r
+++ b/R/result_analysis/utility_functions/extract_city.r
@@ -1,200 +1,96 @@
-library(data.table)
 library(sf)
 library(here)
 library(ggplot2)
 
 
 setwd(here())
+source("R/result_analysis/utility_functions/shape_extraction_functions.r")
 
-########Set constants######## 
-#global
-TIGER_FOLDER = 'datasets/census/tiger'
-REDISTRICTING_FOLDER = 'datasets/census/redistricting'
-DEMO_BG_FOLDER = 'block group demographics'
-CRS_PROJECTION = 4326
+######## Set constants########
+# global
+CRS_PROJECTION <- 4326
 
-P3 = 'DECENNIALPL2020.P3-Data.csv'
-P4 = 'DECENNIALPL2020.P4-Data.csv'
+P3 <- "DECENNIALPL2020.P3-Data.csv"
+P4 <- "DECENNIALPL2020.P4-Data.csv"
 
 
-#runtime
-BLOCK_GEOMETRY_FILES = 'tl_2020_13051_tabblock20'
-BG_GEOMETRY_FILES = 'tl_2020_13051_bg20'
-LOCATION_BASE= 'Savannah_City_of_GA'
-LOCATION_SUP = paste('Intersecting', LOCATION_BASE, sep = '_')
-LOCATION_SUB = paste('Contained_in', LOCATION_BASE, sep = '_')
-CITY_LIMIT_FOLDER = LOCATION_BASE
-CONTAINING_COUNTY = 'Chatham_County_GA'
-CITY_LIMIT_FILE = 'City_Limit'
+# runtime
+BLOCK_GEOMETRY_FILES <- "tl_2020_13051_tabblock20"
+BG_GEOMETRY_FILES <- "tl_2020_13051_bg20"
+LOCATION_BASE <- "Savannah_City_of_GA"
+LOCATION_SUP <- paste("Intersecting", LOCATION_BASE, sep = "_")
+LOCATION_SUB <- paste("Contained_in", LOCATION_BASE, sep = "_")
+CITY_LIMIT_FOLDER <- LOCATION_BASE
+CONTAINING_COUNTY <- "Chatham_County_GA"
+CITY_LIMIT_FILE <- "City_Limit"
 
 
-######Functions#######
+###### Get shape data#######
+county_blocks <- get_shape_data(
+  file.path(TIGER_FOLDER, CONTAINING_COUNTY, paste0(BLOCK_GEOMETRY_FILES, ".shp")), CRS_PROJECTION
+)
+county_bgs <- get_shape_data(
+  file.path(TIGER_FOLDER, CONTAINING_COUNTY, paste0(BG_GEOMETRY_FILES, ".shp")), CRS_PROJECTION
+)
+city_shape <- get_shape_data(
+  file.path(TIGER_FOLDER, CONTAINING_COUNTY, CITY_LIMIT_FOLDER, paste0(CITY_LIMIT_FILE, ".shp")), CRS_PROJECTION
+)
 
-get_shape_data <- function(shape_file_name){
-    #get name of file
-    shape_file<- paste0(TIGER_FOLDER, '/', CONTAINING_COUNTY, '/', shape_file_name, '.shp')
-    #read data
-    shape_data <- st_read(shape_file)
-    #transform data
-    shape_data <- st_transform(shape_data, CRS_PROJECTION)
-    return(shape_data)
-}
-
-#select intersecting or contained shape data from a county, given a city file
-get_shapes_for_city <- function(city_shape_data, county_shape_data, intersection_flag){
-    # make data planar. Otherwise the following line throws an error
-    sf_use_s2(FALSE)
-
-    #choose intersecting or contained data
-    if (intersection_flag){
-        indices <- st_intersects(city_shape_data, county_shape_data, sparse = T)
-    }   
-    else{
-    indices <- st_contains(city_shape_data, county_shape_data, sparse = T)
-    }
-    all_indices <- Reduce(union, indices)
-    relevant_shapes <- county_shape_data[all_indices, ]
-    return(relevant_shapes)
-}
-
-#crop the shapes to be in the city limits, and assign new interior points
-crop_to_city_lines <- function(city_shape_data, county_shape_data){
-    #crop shapes
-    cropped_shapes <- st_intersection(city_shape_data, county_shape_data)
-
-    #in case of multiple connected components make each component unique
-    cropped_shapes$GEOID20 <- gsub('X','',make.names(cropped_shapes$GEOID20, unique = TRUE))
-
-    #create interior point for cropped shapes
-    interior_pt <- st_point_on_surface(cropped_shapes)
-    #calculate a new INTPTLAT20/INTPTLON20 column 
-    interior_pt$INTPTLAT20= st_coordinates(interior_pt)[, 2]
-    interior_pt$INTPTLON20 = st_coordinates(interior_pt)[, 1]
-    
-    #Keep the shape data for joining
-    df_shape <- cropped_shapes[c('GEOID20',"geometry" )]
-    #drop the geometry from the point data for joining
-    interior_pt$geometry <- NULL
-
-    #Join the data and remove columns created by intersection
-    df <- merge(df_shape, interior_pt, by = 'GEOID20', how = left)
-    extra_columns <- c("OBJECTID", "SHAPESTAre", "SHAPESTLen")
-    df <- df[ , !(names(df) %in% extra_columns)]
-    return(df)
-}
-
-write_to_file <- function(shape_data, location_folder, file_name){
-    #check if requisite folder exists, or create it
-    shape_folder = paste0(TIGER_FOLDER, '/', location_folder)
-    if (!file.exists(file.path(here(), shape_folder))){
-        dir.create(file.path(here(), shape_folder))
-    }
-
-    #write to file
-    st_write(shape_data, paste0(shape_folder, '/',  file_name, '.shp'), append = FALSE)
-}
-
-subset_and_write_demo_data <- function(city_shape_data, demo_type, location, bg_flag){
-    #read county demo data, skipping first header
-    if (bg_flag){
-        county_demo_folder = paste0(REDISTRICTING_FOLDER, '/', CONTAINING_COUNTY, '/', DEMO_BG_FOLDER)
-        city_demo_folder = paste0(REDISTRICTING_FOLDER, '/', location, '/', DEMO_BG_FOLDER)
-    } else{
-        county_demo_folder = paste0(REDISTRICTING_FOLDER, '/', CONTAINING_COUNTY)
-        city_demo_folder = paste0(REDISTRICTING_FOLDER, '/', location)
-    }
-    #get header rows. We will append these later
-    headers <- fread(paste0(county_demo_folder, '/', demo_type), nrow = 2)
-
-    #read in county data
-    county_demo <- fread(paste0(county_demo_folder, '/', demo_type), skip = 1, header = T)
-    
-    #extract prefix from Geography column for merging
-    prefix = sub('(US).*', '\\1',county_demo$Geography[1])
-
-    #get unique elements of city_shape data
-    city_ids <- data.table(GEOID20 = city_shape_data$GEOID20)
-
-    #reformat ids for merging
-    city_ids[ , GEOID20:= paste0(prefix, city_ids$GEOID20)  #add prefix in
-            ][ , GEOID20DUP := gsub('\\..*', '', GEOID20)] #remove suffix for merge
-    
-    #merge
-    city_demo <- merge(city_ids, county_demo, by.x = 'GEOID20DUP', by.y = 'Geography', how = 'left' )
-    city_demo$GEOID20DUP <- NULL
-    #write to file, check if it exists first
-    if (!file.exists(file.path(here(), city_demo_folder))){
-        dir.create(file.path(here(), city_demo_folder))
-    }
-
-    #replace the names and add header rows before writing
-    names(city_demo) <- names(headers)
-    city_demo <- rbind(headers, city_demo)
-    fwrite(city_demo, paste0(city_demo_folder, '/', demo_type), append = FALSE, col.names = FALSE)
-}
-
-
-######Get shape data#######
-county_blocks <- get_shape_data(BLOCK_GEOMETRY_FILES)
-county_bgs <- get_shape_data(BG_GEOMETRY_FILES)
-city_shape <- get_shape_data(paste0(CITY_LIMIT_FOLDER, '/', CITY_LIMIT_FILE))
-
-######compute intersecting and contained blocks and block groups######
+###### compute intersecting and contained blocks and block groups######
 intersecting_blocks <- get_shapes_for_city(city_shape, county_blocks, TRUE)
 contained_blocks <- get_shapes_for_city(city_shape, county_blocks, FALSE)
 
 intersecting_bgs <- get_shapes_for_city(city_shape, county_bgs, TRUE)
 contained_bgs <- get_shapes_for_city(city_shape, county_bgs, FALSE)
 
-#####plot, just to see that city blocks is, indeed what one wants #####
+##### plot, just to see that city blocks is, indeed what one wants #####
 ggplot() +
-		geom_sf(data = intersecting_blocks, fill = 'red', alpha = .5) + 
-		geom_sf(data = city_shape, fill = 'yellow', alpha = .5) +
-        geom_sf(data = contained_blocks, fill = 'blue', alpha = .5)  
-ggsave(paste0(TIGER_FOLDER, '/', CONTAINING_COUNTY, '/', CITY_LIMIT_FOLDER, '/', 'block_selection_options.png'))
+  geom_sf(data = intersecting_blocks, fill = "red", alpha = .5) +
+  geom_sf(data = city_shape, fill = "yellow", alpha = .5) +
+  geom_sf(data = contained_blocks, fill = "blue", alpha = .5)
+ggsave(paste0(TIGER_FOLDER, "/", CONTAINING_COUNTY, "/", CITY_LIMIT_FOLDER, "/", "block_selection_options.png"))
 
 ggplot() +
-		geom_sf(data = intersecting_bgs, fill = 'red', alpha = .5) + 
-		geom_sf(data = city_shape, fill = 'yellow', alpha = .5) +
-        geom_sf(data = contained_bgs, fill = 'blue', alpha = .5)  
-ggsave(paste0(TIGER_FOLDER, '/', CONTAINING_COUNTY, '/', CITY_LIMIT_FOLDER, '/', 'bg_selection_options.png'))
+  geom_sf(data = intersecting_bgs, fill = "red", alpha = .5) +
+  geom_sf(data = city_shape, fill = "yellow", alpha = .5) +
+  geom_sf(data = contained_bgs, fill = "blue", alpha = .5)
+ggsave(paste0(TIGER_FOLDER, "/", CONTAINING_COUNTY, "/", CITY_LIMIT_FOLDER, "/", "bg_selection_options.png"))
 
-#get dataframe of city_blocks intersecting the city limits and write to file
-#st_write(city_blocks, paste0(TIGER_FOLDER, '/', LOCATION, '/',  BLOCK_GEOMETRY_FILES, '.shp'))
+# get dataframe of city_blocks intersecting the city limits and write to file
+# st_write(city_blocks, paste0(TIGER_FOLDER, '/', LOCATION, '/',  BLOCK_GEOMETRY_FILES, '.shp'))
 
 
 #######
-#crop intersecting blocks and assign new interior points 
+# crop intersecting blocks and assign new interior points
 #######
 cropped_blocks <- crop_to_city_lines(city_shape, intersecting_blocks)
 cropped_bgs <- crop_to_city_lines(city_shape, intersecting_bgs)
-    #THIS IS A MANUAL CLUDGE TO AVOID A SPECIFIC ERROR.
-    cropped_bgs$geometry_type <- st_geometry_type(cropped_bgs$geometry, by_geometry = T)
-    cropped_bgs <- cropped_bgs[cropped_bgs$geometry_type != 'GEOMETRYCOLLECTION', ]
-    cropped_bgs$geometry_type <- NULL
+# THIS IS A MANUAL CLUDGE TO AVOID A SPECIFIC ERROR.
+cropped_bgs$geometry_type <- st_geometry_type(cropped_bgs$geometry, by_geometry = TRUE)
+cropped_bgs <- cropped_bgs[cropped_bgs$geometry_type != "GEOMETRYCOLLECTION", ]
+cropped_bgs$geometry_type <- NULL
 
 contained_blocks <- crop_to_city_lines(city_shape, contained_blocks)
 contained_bgs <- crop_to_city_lines(city_shape, contained_bgs)
 
-########write shape data to file #########
+######## write shape data to file #########
 write_to_file(cropped_blocks, LOCATION_SUP, BLOCK_GEOMETRY_FILES)
 write_to_file(contained_blocks, LOCATION_SUB, BLOCK_GEOMETRY_FILES)
 
 write_to_file(cropped_bgs, LOCATION_SUP, BG_GEOMETRY_FILES)
 write_to_file(contained_bgs, LOCATION_SUB, BG_GEOMETRY_FILES)
 
-########write demo data to file #########
-#blocks
+######## write demo data to file #########
+# blocks
 subset_and_write_demo_data(cropped_blocks, P3, LOCATION_SUP, FALSE)
 subset_and_write_demo_data(cropped_blocks, P4, LOCATION_SUP, FALSE)
 
 subset_and_write_demo_data(contained_blocks, P3, LOCATION_SUB, FALSE)
 subset_and_write_demo_data(contained_blocks, P4, LOCATION_SUB, FALSE)
 
-#block groups
+# block groups
 subset_and_write_demo_data(cropped_bgs, P3, LOCATION_SUP, TRUE)
 subset_and_write_demo_data(cropped_bgs, P4, LOCATION_SUP, TRUE)
 
 subset_and_write_demo_data(contained_bgs, P3, LOCATION_SUB, TRUE)
 subset_and_write_demo_data(contained_bgs, P4, LOCATION_SUB, TRUE)
-

--- a/R/result_analysis/utility_functions/extract_city.r
+++ b/R/result_analysis/utility_functions/extract_city.r
@@ -82,15 +82,15 @@ write_to_file(contained_bgs, LOCATION_SUB, BG_GEOMETRY_FILES)
 
 ######## write demo data to file #########
 # blocks
-subset_and_write_demo_data(cropped_blocks, P3, LOCATION_SUP, FALSE)
-subset_and_write_demo_data(cropped_blocks, P4, LOCATION_SUP, FALSE)
+subset_and_write_demo_data(cropped_blocks, P3, LOCATION_SUP, FALSE, CONTAINING_COUNTY)
+subset_and_write_demo_data(cropped_blocks, P4, LOCATION_SUP, FALSE, CONTAINING_COUNTY)
 
-subset_and_write_demo_data(contained_blocks, P3, LOCATION_SUB, FALSE)
-subset_and_write_demo_data(contained_blocks, P4, LOCATION_SUB, FALSE)
+subset_and_write_demo_data(contained_blocks, P3, LOCATION_SUB, FALSE, CONTAINING_COUNTY)
+subset_and_write_demo_data(contained_blocks, P4, LOCATION_SUB, FALSE, CONTAINING_COUNTY)
 
 # block groups
-subset_and_write_demo_data(cropped_bgs, P3, LOCATION_SUP, TRUE)
-subset_and_write_demo_data(cropped_bgs, P4, LOCATION_SUP, TRUE)
+subset_and_write_demo_data(cropped_bgs, P3, LOCATION_SUP, TRUE, CONTAINING_COUNTY)
+subset_and_write_demo_data(cropped_bgs, P4, LOCATION_SUP, TRUE, CONTAINING_COUNTY)
 
-subset_and_write_demo_data(contained_bgs, P3, LOCATION_SUB, TRUE)
-subset_and_write_demo_data(contained_bgs, P4, LOCATION_SUB, TRUE)
+subset_and_write_demo_data(contained_bgs, P3, LOCATION_SUB, TRUE, CONTAINING_COUNTY)
+subset_and_write_demo_data(contained_bgs, P4, LOCATION_SUB, TRUE, CONTAINING_COUNTY)

--- a/R/result_analysis/utility_functions/extract_city.r
+++ b/R/result_analysis/utility_functions/extract_city.r
@@ -37,11 +37,11 @@ city_shape <- get_shape_data(
 )
 
 ###### compute intersecting and contained blocks and block groups######
-intersecting_blocks <- get_shapes_for_city(city_shape, county_blocks, TRUE)
-contained_blocks <- get_shapes_for_city(city_shape, county_blocks, FALSE)
+intersecting_blocks <- get_shapes_in_boundary(city_shape, county_blocks, TRUE)
+contained_blocks <- get_shapes_in_boundary(city_shape, county_blocks, FALSE)
 
-intersecting_bgs <- get_shapes_for_city(city_shape, county_bgs, TRUE)
-contained_bgs <- get_shapes_for_city(city_shape, county_bgs, FALSE)
+intersecting_bgs <- get_shapes_in_boundary(city_shape, county_bgs, TRUE)
+contained_bgs <- get_shapes_in_boundary(city_shape, county_bgs, FALSE)
 
 ##### plot, just to see that city blocks is, indeed what one wants #####
 ggplot() +
@@ -63,15 +63,15 @@ ggsave(paste0(TIGER_FOLDER, "/", CONTAINING_COUNTY, "/", CITY_LIMIT_FOLDER, "/",
 #######
 # crop intersecting blocks and assign new interior points
 #######
-cropped_blocks <- crop_to_city_lines(city_shape, intersecting_blocks)
-cropped_bgs <- crop_to_city_lines(city_shape, intersecting_bgs)
+cropped_blocks <- crop_to_boundary(city_shape, intersecting_blocks)
+cropped_bgs <- crop_to_boundary(city_shape, intersecting_bgs)
 # THIS IS A MANUAL CLUDGE TO AVOID A SPECIFIC ERROR.
 cropped_bgs$geometry_type <- st_geometry_type(cropped_bgs$geometry, by_geometry = TRUE)
 cropped_bgs <- cropped_bgs[cropped_bgs$geometry_type != "GEOMETRYCOLLECTION", ]
 cropped_bgs$geometry_type <- NULL
 
-contained_blocks <- crop_to_city_lines(city_shape, contained_blocks)
-contained_bgs <- crop_to_city_lines(city_shape, contained_bgs)
+contained_blocks <- crop_to_boundary(city_shape, contained_blocks)
+contained_bgs <- crop_to_boundary(city_shape, contained_bgs)
 
 ######## write shape data to file #########
 write_to_file(cropped_blocks, LOCATION_SUP, BLOCK_GEOMETRY_FILES)

--- a/R/result_analysis/utility_functions/extract_city.r
+++ b/R/result_analysis/utility_functions/extract_city.r
@@ -13,17 +13,28 @@ CRS_PROJECTION <- 4326
 P3 <- "DECENNIALPL2020.P3-Data.csv"
 P4 <- "DECENNIALPL2020.P4-Data.csv"
 
+#######
+# Read in command line arguments
+# A config file must be given to get the location-specific constants for the
+# extraction to be run: BLOCK_GEOMETRY_FILES, BG_GEOMETRY_FILES,
+# LOCATION_BASE, LOCATION_SUP, LOCATION_SUB, CITY_LIMIT_FOLDER,
+# CONTAINING_COUNTY, CITY_LIMIT_FILE. To extract a new city, add a new
+# config file under R/result_analysis/Extraction_configs/ instead of
+# editing this file.
+#######
 
-# runtime
-BLOCK_GEOMETRY_FILES <- "tl_2020_13051_tabblock20"
-BG_GEOMETRY_FILES <- "tl_2020_13051_bg20"
-LOCATION_BASE <- "Savannah_City_of_GA"
-LOCATION_SUP <- paste("Intersecting", LOCATION_BASE, sep = "_")
-LOCATION_SUB <- paste("Contained_in", LOCATION_BASE, sep = "_")
-CITY_LIMIT_FOLDER <- LOCATION_BASE
-CONTAINING_COUNTY <- "Chatham_County_GA"
-CITY_LIMIT_FILE <- "City_Limit"
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 1) {
+  stop("Must enter exactly one config file")
+} else {
+  config_path <- paste0("R/result_analysis/Extraction_configs/", args[1])
+  source(config_path)
+}
 
+###
+# For inline testing only
+###
+# source("R/result_analysis/Extraction_configs/Savannah_City_of_GA.r")
 
 ###### Get shape data#######
 county_blocks <- get_shape_data(

--- a/R/result_analysis/utility_functions/shape_extraction_functions.r
+++ b/R/result_analysis/utility_functions/shape_extraction_functions.r
@@ -69,13 +69,13 @@ write_to_file <- function(shape_data, location_folder, file_name) {
   st_write(shape_data, paste0(shape_folder, "/", file_name, ".shp"), append = FALSE)
 }
 
-subset_and_write_demo_data <- function(city_shape_data, demo_type, location, bg_flag) {
+subset_and_write_demo_data <- function(city_shape_data, demo_type, location, bg_flag, containing_county) {
   # read county demo data, skipping first header
   if (bg_flag) {
-    county_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", CONTAINING_COUNTY, "/", DEMO_BG_FOLDER)
+    county_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", containing_county, "/", DEMO_BG_FOLDER)
     city_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", location, "/", DEMO_BG_FOLDER)
   } else {
-    county_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", CONTAINING_COUNTY)
+    county_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", containing_county)
     city_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", location)
   }
   # get header rows. We will append these later

--- a/R/result_analysis/utility_functions/shape_extraction_functions.r
+++ b/R/result_analysis/utility_functions/shape_extraction_functions.r
@@ -16,26 +16,31 @@ get_shape_data <- function(shape_file_path, crs_projection) {
   return(shape_data)
 }
 
-# select intersecting or contained shape data from a county, given a city file
-get_shapes_for_city <- function(city_shape_data, county_shape_data, intersection_flag) {
+# select intersecting or contained shape data from a county, given a boundary
+get_shapes_in_boundary <- function(boundary_shape_data, county_shape_data,
+                                   intersection_flag) {
   # make data planar. Otherwise the following line throws an error
   sf_use_s2(FALSE)
 
   # choose intersecting or contained data
   if (intersection_flag) {
-    indices <- st_intersects(city_shape_data, county_shape_data, sparse = TRUE)
+    indices <- st_intersects(boundary_shape_data, county_shape_data,
+      sparse = TRUE
+    )
   } else {
-    indices <- st_contains(city_shape_data, county_shape_data, sparse = TRUE)
+    indices <- st_contains(boundary_shape_data, county_shape_data,
+      sparse = TRUE
+    )
   }
   all_indices <- Reduce(union, indices)
   relevant_shapes <- county_shape_data[all_indices, ]
   return(relevant_shapes)
 }
 
-# crop the shapes to be in the city limits, and assign new interior points
-crop_to_city_lines <- function(city_shape_data, county_shape_data) {
+# crop the shapes to be within the boundary, and assign new interior points
+crop_to_boundary <- function(boundary_shape_data, county_shape_data) {
   # crop shapes
-  cropped_shapes <- st_intersection(city_shape_data, county_shape_data)
+  cropped_shapes <- st_intersection(boundary_shape_data, county_shape_data)
 
   # in case of multiple connected components make each component unique
   cropped_shapes$GEOID20 <- gsub("X", "", make.names(cropped_shapes$GEOID20, unique = TRUE))
@@ -69,14 +74,14 @@ write_to_file <- function(shape_data, location_folder, file_name) {
   st_write(shape_data, paste0(shape_folder, "/", file_name, ".shp"), append = FALSE)
 }
 
-subset_and_write_demo_data <- function(city_shape_data, demo_type, location, bg_flag, containing_county) {
+subset_and_write_demo_data <- function(boundary_shape_data, demo_type, location, bg_flag, containing_county) {
   # read county demo data, skipping first header
   if (bg_flag) {
     county_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", containing_county, "/", DEMO_BG_FOLDER)
-    city_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", location, "/", DEMO_BG_FOLDER)
+    boundary_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", location, "/", DEMO_BG_FOLDER)
   } else {
     county_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", containing_county)
-    city_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", location)
+    boundary_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", location)
   }
   # get header rows. We will append these later
   headers <- fread(paste0(county_demo_folder, "/", demo_type), nrow = 2)
@@ -87,24 +92,24 @@ subset_and_write_demo_data <- function(city_shape_data, demo_type, location, bg_
   # extract prefix from Geography column for merging
   prefix <- sub("(US).*", "\\1", county_demo$Geography[1])
 
-  # get unique elements of city_shape data
-  city_ids <- data.table(GEOID20 = city_shape_data$GEOID20)
+  # get unique elements of boundary_shape data
+  boundary_ids <- data.table(GEOID20 = boundary_shape_data$GEOID20)
 
   # reformat ids for merging
-  city_ids[
-    , GEOID20 := paste0(prefix, city_ids$GEOID20) # add prefix in
+  boundary_ids[
+    , GEOID20 := paste0(prefix, boundary_ids$GEOID20) # add prefix in
   ][, GEOID20DUP := gsub("\\..*", "", GEOID20)] # remove suffix for merge
 
   # merge
-  city_demo <- merge(city_ids, county_demo, by.x = "GEOID20DUP", by.y = "Geography", how = "left")
-  city_demo$GEOID20DUP <- NULL
+  boundary_demo <- merge(boundary_ids, county_demo, by.x = "GEOID20DUP", by.y = "Geography", how = "left")
+  boundary_demo$GEOID20DUP <- NULL
   # write to file, check if it exists first
-  if (!file.exists(file.path(here(), city_demo_folder))) {
-    dir.create(file.path(here(), city_demo_folder))
+  if (!file.exists(file.path(here(), boundary_demo_folder))) {
+    dir.create(file.path(here(), boundary_demo_folder))
   }
 
   # replace the names and add header rows before writing
-  names(city_demo) <- names(headers)
-  city_demo <- rbind(headers, city_demo)
-  fwrite(city_demo, paste0(city_demo_folder, "/", demo_type), append = FALSE, col.names = FALSE)
+  names(boundary_demo) <- names(headers)
+  boundary_demo <- rbind(headers, boundary_demo)
+  fwrite(boundary_demo, paste0(boundary_demo_folder, "/", demo_type), append = FALSE, col.names = FALSE)
 }

--- a/R/result_analysis/utility_functions/shape_extraction_functions.r
+++ b/R/result_analysis/utility_functions/shape_extraction_functions.r
@@ -1,0 +1,110 @@
+library(data.table)
+library(sf)
+library(here)
+
+######## Set constants########
+TIGER_FOLDER <- "datasets/census/tiger"
+REDISTRICTING_FOLDER <- "datasets/census/redistricting"
+DEMO_BG_FOLDER <- "block group demographics"
+
+###### Functions#######
+
+# read a shapefile from an explicit path and reproject it
+get_shape_data <- function(shape_file_path, crs_projection) {
+  shape_data <- st_read(shape_file_path)
+  shape_data <- st_transform(shape_data, crs_projection)
+  return(shape_data)
+}
+
+# select intersecting or contained shape data from a county, given a city file
+get_shapes_for_city <- function(city_shape_data, county_shape_data, intersection_flag) {
+  # make data planar. Otherwise the following line throws an error
+  sf_use_s2(FALSE)
+
+  # choose intersecting or contained data
+  if (intersection_flag) {
+    indices <- st_intersects(city_shape_data, county_shape_data, sparse = TRUE)
+  } else {
+    indices <- st_contains(city_shape_data, county_shape_data, sparse = TRUE)
+  }
+  all_indices <- Reduce(union, indices)
+  relevant_shapes <- county_shape_data[all_indices, ]
+  return(relevant_shapes)
+}
+
+# crop the shapes to be in the city limits, and assign new interior points
+crop_to_city_lines <- function(city_shape_data, county_shape_data) {
+  # crop shapes
+  cropped_shapes <- st_intersection(city_shape_data, county_shape_data)
+
+  # in case of multiple connected components make each component unique
+  cropped_shapes$GEOID20 <- gsub("X", "", make.names(cropped_shapes$GEOID20, unique = TRUE))
+
+  # create interior point for cropped shapes
+  interior_pt <- st_point_on_surface(cropped_shapes)
+  # calculate a new INTPTLAT20/INTPTLON20 column
+  interior_pt$INTPTLAT20 <- st_coordinates(interior_pt)[, 2]
+  interior_pt$INTPTLON20 <- st_coordinates(interior_pt)[, 1]
+
+  # Keep the shape data for joining
+  df_shape <- cropped_shapes[c("GEOID20", "geometry")]
+  # drop the geometry from the point data for joining
+  interior_pt$geometry <- NULL
+
+  # Join the data and remove columns created by intersection
+  df <- merge(df_shape, interior_pt, by = "GEOID20", how = left)
+  extra_columns <- c("OBJECTID", "SHAPESTAre", "SHAPESTLen")
+  df <- df[, !(names(df) %in% extra_columns)]
+  return(df)
+}
+
+write_to_file <- function(shape_data, location_folder, file_name) {
+  # check if requisite folder exists, or create it
+  shape_folder <- paste0(TIGER_FOLDER, "/", location_folder)
+  if (!file.exists(file.path(here(), shape_folder))) {
+    dir.create(file.path(here(), shape_folder))
+  }
+
+  # write to file
+  st_write(shape_data, paste0(shape_folder, "/", file_name, ".shp"), append = FALSE)
+}
+
+subset_and_write_demo_data <- function(city_shape_data, demo_type, location, bg_flag) {
+  # read county demo data, skipping first header
+  if (bg_flag) {
+    county_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", CONTAINING_COUNTY, "/", DEMO_BG_FOLDER)
+    city_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", location, "/", DEMO_BG_FOLDER)
+  } else {
+    county_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", CONTAINING_COUNTY)
+    city_demo_folder <- paste0(REDISTRICTING_FOLDER, "/", location)
+  }
+  # get header rows. We will append these later
+  headers <- fread(paste0(county_demo_folder, "/", demo_type), nrow = 2)
+
+  # read in county data
+  county_demo <- fread(paste0(county_demo_folder, "/", demo_type), skip = 1, header = TRUE)
+
+  # extract prefix from Geography column for merging
+  prefix <- sub("(US).*", "\\1", county_demo$Geography[1])
+
+  # get unique elements of city_shape data
+  city_ids <- data.table(GEOID20 = city_shape_data$GEOID20)
+
+  # reformat ids for merging
+  city_ids[
+    , GEOID20 := paste0(prefix, city_ids$GEOID20) # add prefix in
+  ][, GEOID20DUP := gsub("\\..*", "", GEOID20)] # remove suffix for merge
+
+  # merge
+  city_demo <- merge(city_ids, county_demo, by.x = "GEOID20DUP", by.y = "Geography", how = "left")
+  city_demo$GEOID20DUP <- NULL
+  # write to file, check if it exists first
+  if (!file.exists(file.path(here(), city_demo_folder))) {
+    dir.create(file.path(here(), city_demo_folder))
+  }
+
+  # replace the names and add header rows before writing
+  names(city_demo) <- names(headers)
+  city_demo <- rbind(headers, city_demo)
+  fwrite(city_demo, paste0(city_demo_folder, "/", demo_type), append = FALSE, col.names = FALSE)
+}


### PR DESCRIPTION
Closes #272.

`R/result_analysis/utility_functions/extract_city.r` used to mix five reusable shape-handling functions with a one-off, side-effecting Savannah-City-of-GA/Chatham-County extraction script — so the functions couldn't be reused via `source()` without re-running that unrelated workflow. This is a prerequisite for #266/#267 (extracting and verifying Monongalia County, WV precincts from a statewide shapefile, which need to reuse these functions for a different county/state).

## What changed

- **New file** `R/result_analysis/utility_functions/shape_extraction_functions.r`: the five functions relocated with unchanged bodies, except `get_shape_data()`'s signature was generalized from `get_shape_data(shape_file_name)` (built its own path from globals `TIGER_FOLDER`/`CONTAINING_COUNTY`) to `get_shape_data(shape_file_path, crs_projection)` (caller builds the full path) — needed so it can read both TIGER county shapefiles and a statewide precinct shapefile.
- `extract_city.r` reduced to a thin per-location script: constants + a `source()` call + the unchanged Savannah-specific run.
- Follow-up fix: `subset_and_write_demo_data()` originally still read the global `CONTAINING_COUNTY` (defined only in `extract_city.r`), reintroducing the same implicit-coupling problem for one function. Parameterized it (`containing_county` argument) instead, mirroring the `get_shape_data()` fix.
- Follow-up rename: city-specific names in the shared file (`get_shapes_for_city` → `get_shapes_in_boundary`, `crop_to_city_lines` → `crop_to_boundary`, `city_*` locals → `boundary_*`) since this file is no longer Savannah-specific — it'll be used for precinct boundaries too. `county_*` names and everything in `extract_city.r` itself were intentionally left as-is (those are genuinely about a city/county).
- **Follow-up config-driven refactor**: `extract_city.r` previously hardcoded Savannah's location-specific constants (`BLOCK_GEOMETRY_FILES`, `BG_GEOMETRY_FILES`, `LOCATION_BASE`, `LOCATION_SUP`, `LOCATION_SUB`, `CITY_LIMIT_FOLDER`, `CONTAINING_COUNTY`, `CITY_LIMIT_FILE`) directly in the script — meaning extracting a new city required editing this file. Moved those into a new config file, `R/result_analysis/Extraction_configs/Savannah_City_of_GA.r`, mirroring how `Basic_analysis.r` reads per-location constants from `Basic_analysis_configs/`. `extract_city.r` now takes the config file name as its one required CLI argument (`Rscript extract_city.r Savannah_City_of_GA.r`); running with no argument now errors intentionally ("Must enter exactly one config file"), same contract as `Basic_analysis.r`. `CRS_PROJECTION`/`P3`/`P4` stay in `extract_city.r` itself since they're census-table names and a projection standard, not per-location. This is the pattern #266's new `extract_precincts.r`/`Extraction_configs/Monongalia_County_WV.r` now also follows.

## Verification

- **Zero behavior change**, confirmed empirically at every step: reran `extract_city.r` before and after each change in this branch (including the config-driven refactor, via the new CLI-argument invocation) — all 4 output shapefiles (`tl_2020_13051_tabblock20`/`tl_2020_13051_bg20`, intersecting and contained) produce identical row counts and bounding boxes every time.
- `lintr`/`styler` clean — no new findings introduced at any step (pre-existing findings carried over unchanged, e.g. a latent `merge(how = ...)` no-op argument bug that predates this branch).
- Per-task and final whole-branch reviews completed during implementation (subagent-driven-development), including one Important finding (the `CONTAINING_COUNTY` global coupling) found and fixed before this PR.

@antisocialscientist — please review. Close #272 upon merging.