### PR TITLE
feat(precincts): extract Monongalia County precincts from statewide WV shapefile

### DIFF
--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV.r
@@ -1,4 +1,12 @@
-######## Set constants########
-PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_25/VotingPrecincts_20260424_wmA84.shp"
-COUNTY_FIPS <- "54061"
+########
+# Location data
+########
+
+PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_20260424_wmA84/VotingPrecincts_20260424_wmA84.shp"
+LOCATION <- "Monongalia_County_WV"
+COUNTY_NAME <- sub("\\_.*", "", LOCATION)
+
+########
+# For testing
+########
 EXPECTED_PRECINCT_COUNT <- 44

--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV.r
@@ -1,0 +1,4 @@
+######## Set constants########
+PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_25/VotingPrecincts_20260424_wmA84.shp"
+COUNTY_FIPS <- "54061"
+EXPECTED_PRECINCT_COUNT <- 44

--- a/R/result_analysis/extract_precincts.r
+++ b/R/result_analysis/extract_precincts.r
@@ -1,0 +1,40 @@
+library(sf)
+library(here)
+
+setwd(here())
+source("R/result_analysis/utility_functions/shape_extraction_functions.r")
+
+######## Set constants########
+CRS_PROJECTION <- 4326
+
+#######
+# Read in command line arguments
+# A config file must be given to get the location-specific constants for the
+# extraction to be run. To extract a different county or state, add a new
+# config file under R/result_analysis/Extraction_configs/ instead of editing
+# this file. The config's contents will grow as more steps are added to this
+# script.
+#######
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 1) {
+  stop("Must enter exactly one config file")
+} else {
+  config_path <- paste0("R/result_analysis/Extraction_configs/", args[1])
+  source(config_path)
+}
+
+###
+# For inline testing only
+###
+# source("R/result_analysis/Extraction_configs/Monongalia_County_WV.r")
+
+###### Step 1: extract and validate the county's precincts#######
+county_precincts <- extract_county_precincts(PRECINCT_SOURCE_FILE, COUNTY_FIPS, CRS_PROJECTION)
+
+stopifnot(
+  "Precinct count does not match EXPECTED_PRECINCT_COUNT in the config file" =
+    nrow(county_precincts) == EXPECTED_PRECINCT_COUNT
+)
+
+cat(sprintf("Extracted %d precincts into memory.\n", nrow(county_precincts)))

--- a/R/result_analysis/extract_precincts.r
+++ b/R/result_analysis/extract_precincts.r
@@ -1,11 +1,9 @@
 library(sf)
+library(data.table)
 library(here)
 
 setwd(here())
 source("R/result_analysis/utility_functions/shape_extraction_functions.r")
-
-######## Set constants########
-CRS_PROJECTION <- 4326
 
 #######
 # Read in command line arguments
@@ -29,8 +27,14 @@ if (length(args) != 1) {
 ###
 # source("R/result_analysis/Extraction_configs/Monongalia_County_WV.r")
 
+########
+# Constants
+########
+CRS_PROJECTION <- 4326
+
+
 ###### Step 1: extract and validate the county's precincts#######
-county_precincts <- extract_county_precincts(PRECINCT_SOURCE_FILE, COUNTY_FIPS, CRS_PROJECTION)
+county_precincts <- extract_county_precincts(PRECINCT_SOURCE_FILE, COUNTY_NAME, CRS_PROJECTION)
 
 stopifnot(
   "Precinct count does not match EXPECTED_PRECINCT_COUNT in the config file" =

--- a/R/result_analysis/utility_functions/shape_extraction_functions.r
+++ b/R/result_analysis/utility_functions/shape_extraction_functions.r
@@ -16,16 +16,17 @@ get_shape_data <- function(shape_file_path, crs_projection) {
   return(shape_data)
 }
 
-# select a county's precincts from a statewide precinct shapefile,
-# by FIPS code
-extract_county_precincts <- function(precinct_source_file, county_fips,
+# select a county's precincts from a statewide precinct shapefile, by county
+# name. This is custom built for the WV precinct shapefile and may need
+# generalization.
+extract_county_precincts <- function(precinct_source_file, county_name,
                                      crs_projection) {
   statewide_precincts <- get_shape_data(
     precinct_source_file,
     crs_projection
   )
   county_precincts <- statewide_precincts[
-    which(statewide_precincts$StCoFIPS == county_fips),
+    which(statewide_precincts$County_Nam == county_name),
   ]
   return(county_precincts)
 }

--- a/R/result_analysis/utility_functions/shape_extraction_functions.r
+++ b/R/result_analysis/utility_functions/shape_extraction_functions.r
@@ -16,6 +16,20 @@ get_shape_data <- function(shape_file_path, crs_projection) {
   return(shape_data)
 }
 
+# select a county's precincts from a statewide precinct shapefile,
+# by FIPS code
+extract_county_precincts <- function(precinct_source_file, county_fips,
+                                     crs_projection) {
+  statewide_precincts <- get_shape_data(
+    precinct_source_file,
+    crs_projection
+  )
+  county_precincts <- statewide_precincts[
+    which(statewide_precincts$StCoFIPS == county_fips),
+  ]
+  return(county_precincts)
+}
+
 # select intersecting or contained shape data from a county, given a boundary
 get_shapes_in_boundary <- function(boundary_shape_data, county_shape_data,
                                    intersection_flag) {


### PR DESCRIPTION
Closes #266.

Selects Monongalia County's 44 precincts out of the statewide West Virginia voting-precinct shapefile, reprojects to EPSG:4326, and holds the result in memory as an `sf` object for #267 (and later issues) to consume — no file is written.

## What changed

- **New function** `extract_county_precincts(precinct_source_file, county_name, crs_projection)` added to `R/result_analysis/utility_functions/shape_extraction_functions.r`. Reuses `get_shape_data()` for the read+reproject, then filters by county name.
- **New engine script** `R/result_analysis/extract_precincts.r` + its first config `R/result_analysis/Extraction_configs/Monongalia_County_WV.r`, mirroring `extract_city.r`'s config-driven pattern from #272 exactly (same CLI-argument contract, same error text). The config currently holds `PRECINCT_SOURCE_FILE`, `LOCATION`, `EXPECTED_PRECINCT_COUNT`; it's expected to grow as more steps (#267+) are added to the same script rather than being finalized up front.
- **Filtering by county name, not FIPS code**: the statewide shapefile has rows with no `StCoFIPS` value at all (Lewis and Ohio counties), so FIPS-based filtering isn't reliable statewide. `County_Nam` is consistently present. This also stays consistent with the project's broader convention of keying work off a `<County>_<ST>` location string — `COUNTY_NAME` is derived from the config's existing `LOCATION` value. Filed #277 to track the broader data-quality/versioning implications of the missing-FIPS finding.
- **Caught during review**: an early version of the FIPS-based filter had a real correctness bug — `df[df$StCoFIPS == fips, ]` silently includes one all-`NA` placeholder row per `NA` in the comparison column (since `NA == "54061"` is `NA`, not `FALSE`), which is exactly the class of bug that motivated moving off FIPS codes in the first place. Fixed with `which()` before the switch to county names.

## Verification

- End-to-end: `Rscript R/result_analysis/extract_precincts.r Monongalia_County_WV.r` → `Extracted 44 precincts into memory.` No `NA` in `County_Nam`, no duplicate `Precinct_I`, CRS 4326.
- No-argument path errors intentionally (`Must enter exactly one config file`), matching `extract_city.r`'s contract.
- `lintr`/`styler` clean — no new findings beyond what's already established as precedent in this codebase (SCREAMING_CASE constants, the inline-test `source()` comment convention, etc.).
- Per-task and final whole-branch reviews completed during implementation (subagent-driven-development).
- Branch rebased onto `delivery/Monongalia_County` post-#275-squash-merge to keep this diff scoped to only the new work.

@antisocialscientist — please review. Remove needs review label from #266