### PR TITLE
feat(utils): add RDH predicted whole population path builders

### DIFF
--- a/python/utils/directory_constants.py
+++ b/python/utils/directory_constants.py
@@ -24,6 +24,8 @@ REDISTRICTING_FOLDER_NAME = 'redistricting'
 
 CVAP_FOLDER_NAME = 'CVAP'
 
+RDH_PREDICTED_WHOLE_POPULATION_FOLDER_NAME = 'RDH_predicted_whole_population'
+
 BLOCK_GEO = 'block'
 
 BLOCK_GROUP_GEO = 'block group'

--- a/python/utils/utils.py
+++ b/python/utils/utils.py
@@ -10,10 +10,10 @@ import uuid
 import numpy as np
 
 from python.utils.directory_constants import (
-  BLOCK_GROUP_FILE_SUFFIX, CENSUS_FOLDER_NAME, CENSUS_TIGER_DIR, 
+  BLOCK_GROUP_FILE_SUFFIX, CENSUS_FOLDER_NAME, CENSUS_TIGER_DIR,
   DATASETS_DIR, REDISTRICTING_FOLDER_NAME,
   DRIVING_DIR, POLLING_DIR, TABBLOCK_FILE_SUFFIX,
-  BLOCK_GROUP_GEO, BLOCK_GEO, CVAP_FOLDER_NAME
+  BLOCK_GROUP_GEO, BLOCK_GEO, CVAP_FOLDER_NAME, RDH_PREDICTED_WHOLE_POPULATION_FOLDER_NAME
 )
 
 @dataclass
@@ -180,8 +180,6 @@ def build_redistricting_file_paths(census_year: str, geo: str, pnum: str, locati
 
     return os.path.join(redistricting_dir, file_name)
 
-    return os.path.join(decennial_dir, file_name)
-
 def build_tiger_location_dir(location: str) -> str:
     ''' Returns the path to the Census Tiger data for this location '''
 
@@ -200,6 +198,42 @@ def build_CVAP_source_file_path(census_year: str, location: str) -> str:
     CVAP_dir = build_CVAP_dir_path(location)
 
     return os.path.join(CVAP_dir, file_name_cvap)
+
+# RDH and population are established acronyms in this codebase; mixed case is intentional.
+# pylint: disable-next=invalid-name
+def build_RDH_predicted_whole_population_dir_path(location: str) -> str:
+    """Returns the directory for the RDH predicted whole population block data.
+
+    Args:
+        location: Location identifier, e.g. 'Gwinnett_County_GA'.
+
+    Returns:
+        Absolute path to the RDH_predicted_whole_population directory for this location.
+    """
+    return os.path.join(DATASETS_DIR, CENSUS_FOLDER_NAME, RDH_PREDICTED_WHOLE_POPULATION_FOLDER_NAME, location)
+
+# pylint: disable-next=invalid-name
+def build_RDH_predicted_whole_population_source_file_path(location: str, projection_year: str) -> str:
+    """Returns the path to the RDH predicted whole population data CSV for a location.
+
+    Scans the location directory for a CSV file, since RDH filenames include the state
+    abbreviation and year range (e.g. 'ga_pop_proj_2026_2035_b.csv') and are not
+    predictable from the location string alone. projection_year is used only in the
+    fallback path returned when no CSV is found, to produce a meaningful error message.
+
+    Args:
+        location: Location identifier, e.g. 'Gwinnett_County_GA'.
+        projection_year: The population projection year to extract, e.g. '2026'.
+
+    Returns:
+        Absolute path to the first CSV found in the directory, or a fallback path if none exists.
+    """
+    directory = build_RDH_predicted_whole_population_dir_path(location)
+    if os.path.isdir(directory):
+        csv_files = sorted(f for f in os.listdir(directory) if f.endswith('.csv'))
+        if csv_files:
+            return os.path.join(directory, csv_files[0])
+    return os.path.join(directory, f'pop_proj_{projection_year}_b.csv')
 
 
 def get_block_source_file_path(census_year, location: str) -> str:


### PR DESCRIPTION
## Summary

- Adds `RDH_PREDICTED_WHOLE_POPULATION_FOLDER_NAME` constant to `directory_constants.py`
- Adds `build_RDH_predicted_whole_population_dir_path(location)` to `utils.py` — returns `datasets/census/RDH_predicted_whole_population/<location>/`
- Adds `build_RDH_predicted_whole_population_source_file_path(location, projection_year)` to `utils.py` — scans the directory for any `.csv` rather than constructing a fixed name, since RDH filenames encode state abbreviation and year range (e.g. `ga_pop_proj_2026_2035_b.csv`) and cannot be derived from the location string alone; falls back to a synthetic path for a meaningful error message when no file is present yet

Follows the existing pattern used for `CVAP` and `redistricting` path builders.

## Test plan

- [ ] `pytest python/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)