### PR TITLE
feat(precincts): flag census blocks >5mi from assigned polling location (#269)

### DIFF
--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV.r
@@ -11,17 +11,32 @@ COUNTY_NAME <- sub("\\_.*", "", LOCATION)
 STATE_PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_20260424_wmA84/VotingPrecincts_20260424_wmA84.shp"
 
 ########
-# County-provided precinct/polling-location reconciliation (#282)
+# County-provided precinct/polling-location reconciliation
 ########
 #Did the county provide precinct <-> polling location data
 COUNTY_PROVIDES_PRECINCT_DATA <- TRUE 
 #if so, where is it located
-#TODO: what happens if this isn't provided? "null? error handling?"
-COUNTY_PROVIDED_PRECINCT_FILE <- "temp/Precincts_by_Location.csv"
-#Column name of the polling location
-COUNTY_POLLING_LOCATION_NAME_COL <- "Polling Place Name"
-COUNTY_POLLING_LOCATION_ADDRESS_COL <- "Polling Location Address"
-COUNTY_PRECINCT_COLUMN_NAMES <- c("Prec", "Prec", "Prec", "Prec", "Prec", "Prec")
+COUNTY_PROVIDED_PRECINCT_FILE <- "temp/Precincts_by_Location.csv" #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+#details specific to the file
+COUNTY_POLLING_LOCATION_NAME_COL <- "Polling Place Name" #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+COUNTY_POLLING_LOCATION_ADDRESS_COL <- "Polling Location Address" #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+COUNTY_PRECINCT_COLUMN_NAMES <- c("Prec", "Prec", "Prec", "Prec", "Prec", "Prec") #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+
+#check that proper file / columns names are added if and only if the county provides data
+county_provided_data_names <- list(COUNTY_PROVIDED_PRECINCT_FILE, COUNTY_POLLING_LOCATION_NAME_COL,
+                                    COUNTY_POLLING_LOCATION_ADDRESS_COL, COUNTY_PRECINCT_COLUMN_NAMES)
+if (COUNTY_PROVIDES_PRECINCT_DATA) {
+  if (any(sapply(county_provided_data_names, is.null))) {
+    stop("COUNTY_PROVIDED_ file, precinct location name column, or precinct address column cannot be null
+        if COUNTY_PROVIDES_PRECINCT_DATA is TRUE")
+  }
+} else { #COUNTY_PROVIDES_PRECINCT_DATA is FALSE
+  if (any(!sapply(county_provided_data_names, is.null))) {
+    stop("COUNTY_PROVIDED_ file, precinct location name column, or precinct address columns must be null
+        if COUNTY_PROVIDES_PRECINCT_DATA is FALSE")
+  }
+}
+
 
 ########
 # For testing
@@ -29,6 +44,6 @@ COUNTY_PRECINCT_COLUMN_NAMES <- c("Prec", "Prec", "Prec", "Prec", "Prec", "Prec"
 #EXPECTED_PRECINCT_COUNT <- 44
 
 ########
-# Block geometry, for Step 2 (issue #267)
+# Block geometry, for Step 2  
 ########
 BLOCK_GEOMETRY_FILES <- "tl_2020_54061_tabblock20"

--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV.r
@@ -5,8 +5,10 @@
 LOCATION <- "Monongalia_County_WV"
 COUNTY_NAME <- sub("\\_.*", "", LOCATION)
 
+######
+#data set locations
+######
 STATE_PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_20260424_wmA84/VotingPrecincts_20260424_wmA84.shp"
-COUNTY_PRECINCT_SOURCE_FILE <- paste0("datasets/polling/", LOCATION, "/", LOCATION, "_potential_locations.csv")
 
 ########
 # County-provided precinct/polling-location reconciliation (#282)
@@ -30,11 +32,3 @@ COUNTY_PRECINCT_COLUMN_NAMES <- c("Prec", "Prec", "Prec", "Prec", "Prec", "Prec"
 # Block geometry, for Step 2 (issue #267)
 ########
 BLOCK_GEOMETRY_FILES <- "tl_2020_54061_tabblock20"
-
-########
-# Driving distances, for Step 6 (issue #269)
-########
-DRIVING_DISTANCE_SUFFIX <- "_driving_distances.csv"
-DRIVING_DISTANCES_FILE <- paste0(
-  "datasets/driving/", LOCATION, "/", LOCATION, DRIVING_DISTANCE_SUFFIX
-)

--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV.r
@@ -35,4 +35,6 @@ BLOCK_GEOMETRY_FILES <- "tl_2020_54061_tabblock20"
 # Driving distances, for Step 6 (issue #269)
 ########
 DRIVING_DISTANCE_SUFFIX <- "_driving_distances.csv"
-DRIVING_DISTANCES_FILE <- paste0("datasets/driving/", LOCATION, "/", LOCATION, DRIVING_DISTANCE_SUFFIX)
+DRIVING_DISTANCES_FILE <- paste0(
+  "datasets/driving/", LOCATION, "/", LOCATION, DRIVING_DISTANCE_SUFFIX
+)

--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV.r
@@ -30,3 +30,9 @@ COUNTY_PRECINCT_COLUMN_NAMES <- c("Prec", "Prec", "Prec", "Prec", "Prec", "Prec"
 # Block geometry, for Step 2 (issue #267)
 ########
 BLOCK_GEOMETRY_FILES <- "tl_2020_54061_tabblock20"
+
+########
+# Driving distances, for Step 6 (issue #269)
+########
+DRIVING_DISTANCE_SUFFIX <- "_driving_distances.csv"
+DRIVING_DISTANCES_FILE <- paste0("datasets/driving/", LOCATION, "/", LOCATION, DRIVING_DISTANCE_SUFFIX)

--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV_id_mismatch.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV_id_mismatch.r
@@ -5,6 +5,10 @@
 LOCATION <- "Monongalia_County_WV"
 COUNTY_NAME <- sub("\\_.*", "", LOCATION)
 
+######
+#data set locations
+######
+
 # Names corrected, but precinct-ID mappings not yet reconciled with the
 # county (Granville 44 still assigned to the Fire Dept Bingo Hall, no
 # Monongalia_2A/2B split). Used to exercise check_precinct_id_agreement()'s
@@ -12,17 +16,31 @@ COUNTY_NAME <- sub("\\_.*", "", LOCATION)
 STATE_PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_20260424_wmA84_old_precinct_ids/VotingPrecincts_20260424_wmA84_old_precinct_ids.shp"
 
 ########
-# County-provided precinct/polling-location reconciliation (#282)
+# County-provided precinct/polling-location reconciliation 
 ########
 #Did the county provide precinct <-> polling location data
 COUNTY_PROVIDES_PRECINCT_DATA <- TRUE
 #if so, where is it located
-#TODO: what happens if this isn't provided? "null? error handling?"
-COUNTY_PROVIDED_PRECINCT_FILE <- "temp/Precincts_by_Location.csv"
-#Column name of the polling location
-COUNTY_POLLING_LOCATION_NAME_COL <- "Polling Place Name"
-COUNTY_POLLING_LOCATION_ADDRESS_COL <- "Polling Location Address"
-COUNTY_PRECINCT_COLUMN_NAMES <- c("Prec", "Prec", "Prec", "Prec", "Prec", "Prec")
+COUNTY_PROVIDED_PRECINCT_FILE <- "temp/Precincts_by_Location.csv" #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+#details specific to the file
+COUNTY_POLLING_LOCATION_NAME_COL <- "Polling Place Name" #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+COUNTY_POLLING_LOCATION_ADDRESS_COL <- "Polling Location Address" #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+COUNTY_PRECINCT_COLUMN_NAMES <- c("Prec", "Prec", "Prec", "Prec", "Prec", "Prec") #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+
+#check that proper file / columns names are added if and only if the county provides data
+county_provided_data_names <- list(COUNTY_PROVIDED_PRECINCT_FILE, COUNTY_POLLING_LOCATION_NAME_COL,
+                                    COUNTY_POLLING_LOCATION_ADDRESS_COL, COUNTY_PRECINCT_COLUMN_NAMES)
+if (COUNTY_PROVIDES_PRECINCT_DATA) {
+  if (any(sapply(county_provided_data_names, is.null))) {
+    stop("COUNTY_PROVIDED_ file, precinct location name column, or precinct address column cannot be null
+        if COUNTY_PROVIDES_PRECINCT_DATA is TRUE")
+  }
+} else { #COUNTY_PROVIDES_PRECINCT_DATA is FALSE
+  if (any(!sapply(county_provided_data_names, is.null))) {
+    stop("COUNTY_PROVIDED_ file, precinct location name column, or precinct address columns must be null
+        if COUNTY_PROVIDES_PRECINCT_DATA is FALSE")
+  }
+}
 
 ########
 # For testing
@@ -30,6 +48,6 @@ COUNTY_PRECINCT_COLUMN_NAMES <- c("Prec", "Prec", "Prec", "Prec", "Prec", "Prec"
 #EXPECTED_PRECINCT_COUNT <- 44
 
 ########
-# Block geometry, for Step 2 (issue #267)
+# Block geometry, for Step 2 
 ########
 BLOCK_GEOMETRY_FILES <- "tl_2020_54061_tabblock20"

--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV_id_mismatch.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV_id_mismatch.r
@@ -10,7 +10,6 @@ COUNTY_NAME <- sub("\\_.*", "", LOCATION)
 # Monongalia_2A/2B split). Used to exercise check_precinct_id_agreement()'s
 # stop() error.
 STATE_PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_20260424_wmA84_old_precinct_ids/VotingPrecincts_20260424_wmA84_old_precinct_ids.shp"
-COUNTY_PRECINCT_SOURCE_FILE <- paste0("datasets/polling/", LOCATION, "/", LOCATION, "_potential_locations.csv")
 
 ########
 # County-provided precinct/polling-location reconciliation (#282)

--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV_long_precinct_format.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV_long_precinct_format.r
@@ -5,10 +5,13 @@
 LOCATION <- "Monongalia_County_WV"
 COUNTY_NAME <- sub("\\_.*", "", LOCATION)
 
+######
+#data set locations
+######
 STATE_PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_20260424_wmA84/VotingPrecincts_20260424_wmA84.shp"
 
 ########
-# County-provided precinct/polling-location reconciliation (#282)
+# County-provided precinct/polling-location reconciliation
 #
 # Same as Monongalia_County_WV.r, except COUNTY_PROVIDED_PRECINCT_FILE points
 # at a long-format file (one row per precinct, via
@@ -20,12 +23,26 @@ STATE_PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_20260424_wmA84/V
 #Did the county provide precinct <-> polling location data
 COUNTY_PROVIDES_PRECINCT_DATA <- TRUE
 #if so, where is it located
-#TODO: what happens if this isn't provided? "null? error handling?"
-COUNTY_PROVIDED_PRECINCT_FILE <- "temp/Precincts_by_Location_long.csv"
-#Column name of the polling location
-COUNTY_POLLING_LOCATION_NAME_COL <- "Polling Place Name"
-COUNTY_POLLING_LOCATION_ADDRESS_COL <- "Polling Location Address"
-COUNTY_PRECINCT_COLUMN_NAMES <- c("Precinct")
+COUNTY_PROVIDED_PRECINCT_FILE <- "temp/Precincts_by_Location_long.csv" #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+#details specific to the file
+COUNTY_POLLING_LOCATION_NAME_COL <- "Polling Place Name" #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+COUNTY_POLLING_LOCATION_ADDRESS_COL <- "Polling Location Address" #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+COUNTY_PRECINCT_COLUMN_NAMES <- c("Precinct") #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+
+#check that proper file / columns names are added if and only if the county provides data
+county_provided_data_names <- list(COUNTY_PROVIDED_PRECINCT_FILE, COUNTY_POLLING_LOCATION_NAME_COL,
+                                    COUNTY_POLLING_LOCATION_ADDRESS_COL, COUNTY_PRECINCT_COLUMN_NAMES)
+if (COUNTY_PROVIDES_PRECINCT_DATA) {
+  if (any(sapply(county_provided_data_names, is.null))) {
+    stop("COUNTY_PROVIDED_ file, precinct location name column, or precinct address column cannot be null
+        if COUNTY_PROVIDES_PRECINCT_DATA is TRUE")
+  }
+} else { #COUNTY_PROVIDES_PRECINCT_DATA is FALSE
+  if (any(!sapply(county_provided_data_names, is.null))) {
+    stop("COUNTY_PROVIDED_ file, precinct location name column, or precinct address columns must be null
+        if COUNTY_PROVIDES_PRECINCT_DATA is FALSE")
+  }
+}
 
 ########
 # For testing
@@ -33,6 +50,6 @@ COUNTY_PRECINCT_COLUMN_NAMES <- c("Precinct")
 #EXPECTED_PRECINCT_COUNT <- 44
 
 ########
-# Block geometry, for Step 2 (issue #267)
+# Block geometry, for Step 2  
 ########
 BLOCK_GEOMETRY_FILES <- "tl_2020_54061_tabblock20"

--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV_long_precinct_format.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV_long_precinct_format.r
@@ -6,7 +6,6 @@ LOCATION <- "Monongalia_County_WV"
 COUNTY_NAME <- sub("\\_.*", "", LOCATION)
 
 STATE_PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_20260424_wmA84/VotingPrecincts_20260424_wmA84.shp"
-COUNTY_PRECINCT_SOURCE_FILE <- paste0("datasets/polling/", LOCATION, "/", LOCATION, "_potential_locations.csv")
 
 ########
 # County-provided precinct/polling-location reconciliation (#282)

--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV_name_mismatch.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV_name_mismatch.r
@@ -9,7 +9,6 @@ COUNTY_NAME <- sub("\\_.*", "", LOCATION)
 # naming (e.g. "BOPARC SENIOR/COMMUNITY CENTER" vs the county's "BOPARC Senior
 # Recreation Center"). Used to exercise match_location_names()'s stop() error.
 STATE_PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_20260424_wmA84_old_names/VotingPrecincts_20260424_wmA84_old_names.shp"
-COUNTY_PRECINCT_SOURCE_FILE <- paste0("datasets/polling/", LOCATION, "/", LOCATION, "_potential_locations.csv")
 
 ########
 # County-provided precinct/polling-location reconciliation (#282)

--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV_name_mismatch.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV_name_mismatch.r
@@ -5,23 +5,42 @@
 LOCATION <- "Monongalia_County_WV"
 COUNTY_NAME <- sub("\\_.*", "", LOCATION)
 
-# Pre-#268 state shapefile: USER_POLL_ names don't yet match the county's
-# naming (e.g. "BOPARC SENIOR/COMMUNITY CENTER" vs the county's "BOPARC Senior
+
+######
+#data set locations
+######
+
+# In this state shapefile, USER_POLL_ names don't yet match the county's
+# naming (e.g. "BOPARC SENIOR/COMMUNITY CENTER" vs  "BOPARC Senior
 # Recreation Center"). Used to exercise match_location_names()'s stop() error.
 STATE_PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_20260424_wmA84_old_names/VotingPrecincts_20260424_wmA84_old_names.shp"
 
 ########
-# County-provided precinct/polling-location reconciliation (#282)
+# County-provided precinct/polling-location reconciliation
 ########
 #Did the county provide precinct <-> polling location data
 COUNTY_PROVIDES_PRECINCT_DATA <- TRUE
 #if so, where is it located
-#TODO: what happens if this isn't provided? "null? error handling?"
-COUNTY_PROVIDED_PRECINCT_FILE <- "temp/Precincts_by_Location.csv"
-#Column name of the polling location
-COUNTY_POLLING_LOCATION_NAME_COL <- "Polling Place Name"
-COUNTY_POLLING_LOCATION_ADDRESS_COL <- "Polling Location Address"
-COUNTY_PRECINCT_COLUMN_NAMES <- c("Prec", "Prec", "Prec", "Prec", "Prec", "Prec")
+COUNTY_PROVIDED_PRECINCT_FILE <- "temp/Precincts_by_Location.csv" #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+#details specific to the file
+COUNTY_POLLING_LOCATION_NAME_COL <- "Polling Place Name" #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+COUNTY_POLLING_LOCATION_ADDRESS_COL <- "Polling Location Address" #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+COUNTY_PRECINCT_COLUMN_NAMES <- c("Prec", "Prec", "Prec", "Prec", "Prec", "Prec") #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+
+#check that proper file / columns names are added if and only if the county provides data
+county_provided_data_names <- list(COUNTY_PROVIDED_PRECINCT_FILE, COUNTY_POLLING_LOCATION_NAME_COL,
+                                    COUNTY_POLLING_LOCATION_ADDRESS_COL, COUNTY_PRECINCT_COLUMN_NAMES)
+if (COUNTY_PROVIDES_PRECINCT_DATA) {
+  if (any(sapply(county_provided_data_names, is.null))) {
+    stop("COUNTY_PROVIDED_ file, precinct location name column, or precinct address column cannot be null
+        if COUNTY_PROVIDES_PRECINCT_DATA is TRUE")
+  }
+} else { #COUNTY_PROVIDES_PRECINCT_DATA is FALSE
+  if (any(!sapply(county_provided_data_names, is.null))) {
+    stop("COUNTY_PROVIDED_ file, precinct location name column, or precinct address columns must be null
+        if COUNTY_PROVIDES_PRECINCT_DATA is FALSE")
+  }
+}
 
 ########
 # For testing
@@ -29,6 +48,6 @@ COUNTY_PRECINCT_COLUMN_NAMES <- c("Prec", "Prec", "Prec", "Prec", "Prec", "Prec"
 #EXPECTED_PRECINCT_COUNT <- 44
 
 ########
-# Block geometry, for Step 2 (issue #267)
+# Block geometry, for Step 2  
 ########
 BLOCK_GEOMETRY_FILES <- "tl_2020_54061_tabblock20"

--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV_no_precinct_data.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV_no_precinct_data.r
@@ -6,7 +6,6 @@ LOCATION <- "Monongalia_County_WV"
 COUNTY_NAME <- sub("\\_.*", "", LOCATION)
 
 STATE_PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_20260424_wmA84/VotingPrecincts_20260424_wmA84.shp"
-COUNTY_PRECINCT_SOURCE_FILE <- paste0("datasets/polling/", LOCATION, "/", LOCATION, "_potential_locations.csv")
 
 ########
 # County-provided precinct/polling-location reconciliation (#282)

--- a/R/result_analysis/Extraction_configs/Monongalia_County_WV_no_precinct_data.r
+++ b/R/result_analysis/Extraction_configs/Monongalia_County_WV_no_precinct_data.r
@@ -5,15 +5,35 @@
 LOCATION <- "Monongalia_County_WV"
 COUNTY_NAME <- sub("\\_.*", "", LOCATION)
 
+######
+#data set locations
+######
 STATE_PRECINCT_SOURCE_FILE <- "datasets/precincts/West_Virginia_20260424_wmA84/VotingPrecincts_20260424_wmA84.shp"
 
 ########
-# County-provided precinct/polling-location reconciliation (#282)
+# County-provided precinct/polling-location reconciliation
 ########
 COUNTY_PROVIDES_PRECINCT_DATA <- FALSE
-COUNTY_PROVIDED_PRECINCT_FILE <- "temp/Precincts_by_Location.csv"
-COUNTY_PRECINCT_LOCATION_NAME_COL <- "Polling Place Name"
-COUNTY_PRECINCT_ADDRESS_COL <- "Polling Location Address"
+COUNTY_PROVIDED_PRECINCT_FILE <- NULL #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+#details specific to the file
+COUNTY_POLLING_LOCATION_NAME_COL <- NULL #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+COUNTY_POLLING_LOCATION_ADDRESS_COL <- NULL #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+COUNTY_PRECINCT_COLUMN_NAMES <- NULL #cannnot be null if COUNTY_PROVIDES_PRECINCT_DATA is TRUE
+
+#check that proper file / columns names are added if and only if the county provides data
+county_provided_data_names <- list(COUNTY_PROVIDED_PRECINCT_FILE, COUNTY_POLLING_LOCATION_NAME_COL,
+                                    COUNTY_POLLING_LOCATION_ADDRESS_COL, COUNTY_PRECINCT_COLUMN_NAMES)
+if (COUNTY_PROVIDES_PRECINCT_DATA) {
+  if (any(sapply(county_provided_data_names, is.null))) {
+    stop("COUNTY_PROVIDED_ file, precinct location name column, or precinct address column cannot be null
+        if COUNTY_PROVIDES_PRECINCT_DATA is TRUE")
+  }
+} else { #COUNTY_PROVIDES_PRECINCT_DATA is FALSE
+  if (any(!sapply(county_provided_data_names, is.null))) {
+    stop("COUNTY_PROVIDED_ file, precinct location name column, or precinct address columns must be null
+        if COUNTY_PROVIDES_PRECINCT_DATA is FALSE")
+  }
+}
 
 ########
 # For testing
@@ -21,6 +41,6 @@ COUNTY_PRECINCT_ADDRESS_COL <- "Polling Location Address"
 #EXPECTED_PRECINCT_COUNT <- 44
 
 ########
-# Block geometry, for Step 2 (issue #267)
+# Block geometry, for Step 2  
 ########
 BLOCK_GEOMETRY_FILES <- "tl_2020_54061_tabblock20"

--- a/R/result_analysis/extract_precincts.r
+++ b/R/result_analysis/extract_precincts.r
@@ -128,3 +128,27 @@ county_precincts_resolved <- county_precincts_resolved[
   county_precincts_resolved$total_population > 0,
 ]
 county_precincts_resolved$total_population <- NULL
+
+###### Step 6: flag blocks far from their assigned polling location (#269) #######
+
+# 5 miles in meters. Explicit stand-in for "more than a 15-minute drive"
+# until real drive-time data exists.
+# TODO(#271): replace with a time-based threshold once driving *time* (not
+# just distance) is available.
+DISTANCE_FLAG_THRESHOLD_M <- 8046.72
+
+p4_file_path <- file.path(REDISTRICTING_FOLDER, LOCATION, "DECENNIALPL2020.P4-Data.csv")
+block_demographics <- get_block_demographics(p3_file_path, p4_file_path)
+
+distance_flagged_blocks <- flag_distant_blocks(
+  block_precinct_assignment, block_demographics,
+  DRIVING_DISTANCES_FILE, COUNTY_PRECINCT_SOURCE_FILE, DISTANCE_FLAG_THRESHOLD_M
+)
+
+distance_flagged_blocks_path <- file.path(precinct_analysis_output_folder, "distance_flagged_blocks.csv")
+fwrite(distance_flagged_blocks, distance_flagged_blocks_path)
+
+cat(sprintf(
+  "Wrote %d-row distance-flagged block table to %s\n",
+  nrow(distance_flagged_blocks), distance_flagged_blocks_path
+))

--- a/R/result_analysis/extract_precincts.r
+++ b/R/result_analysis/extract_precincts.r
@@ -142,7 +142,9 @@ block_demographics <- get_block_demographics(p3_file_path, p4_file_path)
 
 distance_flagged_blocks <- flag_distant_blocks(
   block_precinct_assignment, block_demographics,
-  DRIVING_DISTANCES_FILE, COUNTY_PRECINCT_SOURCE_FILE, DISTANCE_FLAG_THRESHOLD_M
+  build_driving_distances_file_path(LOCATION),
+  build_potential_locations_file_path(LOCATION),
+  DISTANCE_FLAG_THRESHOLD_M
 )
 
 distance_flagged_blocks_path <- file.path(precinct_analysis_output_folder, "distance_flagged_blocks.csv")

--- a/R/result_analysis/extract_precincts.r
+++ b/R/result_analysis/extract_precincts.r
@@ -129,7 +129,7 @@ county_precincts_resolved <- county_precincts_resolved[
 ]
 county_precincts_resolved$total_population <- NULL
 
-###### Step 6: flag blocks far from their assigned polling location (#269) #######
+###### Step 6: flag blocks far from their assigned polling location #######
 
 # 5 miles in meters. Explicit stand-in for "more than a 15-minute drive"
 # until real drive-time data exists.

--- a/R/result_analysis/utility_functions/shape_extraction_functions.r
+++ b/R/result_analysis/utility_functions/shape_extraction_functions.r
@@ -328,18 +328,21 @@ flag_distant_blocks <- function(block_precinct_assignment, block_demographics,
   potential_locations <- fread(potential_locations_file)
   potential_locations[, USER_POLL_ := toupper(Location)]
 
-  # Step 5 of extract_precincts.r (reconciled_state_precinct_data(), via
-  # match_location_names()) already errors on any USER_POLL_ that doesn't
-  # case-insensitively match the county-provided file. If the stopifnot
-  # below ever fires, Step 5's reconciliation and potential_locations.csv
-  # have gone out of sync with each other -- that's an unexpected state
-  # worth investigating directly, not a case to silently drop or guess at.
+  # Agreement between USER_POLL_ and potential_locations.csv's Location
+  # column was established out-of-band by a one-off manual correction
+  # (scratch_correct_state_precinct_names.r) -- Step 5's
+  # match_location_names() only validates the county-provided precinct file
+  # against the state shapefile, it never checks potential_locations.csv.
+  # The stopifnot below is this pairing's real, active runtime guard: if it
+  # ever fires, potential_locations.csv and USER_POLL_ have gone out of
+  # sync -- an unexpected state worth investigating directly, not a case to
+  # silently drop or guess at.
   resolved_blocks <- merge(
     populated_blocks, potential_locations[, .(USER_POLL_, Location)],
     by = "USER_POLL_"
   )
   stopifnot(
-    "Some populated blocks' USER_POLL_ did not match any potential_locations.csv Location" =
+    "Populated blocks' USER_POLL_ and potential_locations.csv's Location did not match one-to-one -- either some USER_POLL_ values are missing from potential_locations.csv (rows dropped), or potential_locations.csv has duplicate Location values (rows multiplied)" =
       nrow(resolved_blocks) == nrow(populated_blocks)
   )
 
@@ -350,6 +353,10 @@ flag_distant_blocks <- function(block_precinct_assignment, block_demographics,
     resolved_blocks, driving_distances,
     by.x = c("GEOID20", "Location"), by.y = c("id_orig", "id_dest")
   )
+  stopifnot(
+    "Some resolved blocks' (GEOID20, Location) pair had no matching row in driving_distances_file -- driving_distances_file may be incomplete or out of sync with potential_locations.csv, or vice versa" =
+      nrow(distance_blocks) == nrow(resolved_blocks)
+  )
 
   # drop block_demographics' total_population before merging -- it's the
   # same figure already carried on distance_blocks (both trace back to the
@@ -359,6 +366,10 @@ flag_distant_blocks <- function(block_precinct_assignment, block_demographics,
   demographic_blocks <- merge(
     distance_blocks, block_demographics[, c("GEOID20", demographic_columns), with = FALSE],
     by = "GEOID20"
+  )
+  stopifnot(
+    "Some distance-joined blocks' GEOID20 had no matching row in block_demographics -- block_demographics may be incomplete or out of sync with the block/precinct assignment, or vice versa" =
+      nrow(demographic_blocks) == nrow(distance_blocks)
   )
 
   demographic_blocks[, Weighted_dist := total_population * distance_m]

--- a/R/result_analysis/utility_functions/shape_extraction_functions.r
+++ b/R/result_analysis/utility_functions/shape_extraction_functions.r
@@ -7,6 +7,10 @@ library(dplyr)
 TIGER_FOLDER <- "datasets/census/tiger"
 REDISTRICTING_FOLDER <- "datasets/census/redistricting"
 DEMO_BG_FOLDER <- "block group demographics"
+POLLING_FOLDER <- "datasets/polling"
+POTENTIAL_LOCATIONS_SUFFIX <- "_potential_locations.csv"
+DRIVING_FOLDER <- "datasets/driving"
+DRIVING_DISTANCE_SUFFIX <- "_driving_distances.csv"
 
 
 CRS_PROJECTION <- 4326
@@ -18,6 +22,25 @@ get_shape_data <- function(shape_file_path, crs_projection=CRS_PROJECTION) {
   shape_data <- st_read(shape_file_path)
   shape_data <- st_transform(shape_data, crs_projection)
   return(shape_data)
+}
+
+# path to a location's potential-locations CSV (the file the solver reads
+# polling locations from, and the source generate_driving_distances_cli.py
+# geocodes into the driving-distances matrix). Mirrors
+# python/utils/utils.py's build_potential_locations_file_path().
+build_potential_locations_file_path <- function(location, polling_folder = POLLING_FOLDER,
+                                                potential_locations_suffix = POTENTIAL_LOCATIONS_SUFFIX) {
+  return(file.path(
+    polling_folder, location, paste0(location, potential_locations_suffix)
+  ))
+}
+
+# path to a location's driving-distances CSV.
+build_driving_distances_file_path <- function(location, driving_folder = DRIVING_FOLDER,
+                                              driving_distance_suffix = DRIVING_DISTANCE_SUFFIX) {
+  return(file.path(
+    driving_folder, location, paste0(location, driving_distance_suffix)
+  ))
 }
 
 # select a county's precincts from a statewide precinct shapefile, by county
@@ -280,22 +303,26 @@ assign_block_to_dominant_precinct <- function(county_precincts, county_blocks,
 # wired up for R-calls-Python anywhere in this project and the python
 # function is pandas/solver-specific.
 get_block_demographics <- function(p3_file_path, p4_file_path) {
-  p3_demographics <- fread(
-    p3_file_path,
-    header = FALSE, skip = 2,
-    select = c(1, 3, 5, 6, 7, 8, 9, 10, 11),
-    col.names = c(
-      "GEO_ID", "total_population", "white", "black", "native", "asian",
-      "pacific_islander", "other", "multiple_races"
-    )
-  )
+  # row 1 holds the real census column codes (GEO_ID, NAME, P3_001N, ...);
+  # row 2 holds long descriptive labels; data starts at row 3. Read row 1
+  # as the header, then re-read the data with those names attached, so
+  # columns below are selected by their actual census code (matching
+  # python/solver/constants.py's CEN20_P3_*/CEN20_P4_*) rather than by
+  # position.
+  p3_header <- names(fread(p3_file_path, nrows = 0))
+  p3_raw <- fread(p3_file_path, header = FALSE, skip = 2, col.names = p3_header)
+  p3_demographics <- p3_raw[, .(
+    GEO_ID, total_population = P3_001N, white = P3_003N, black = P3_004N,
+    native = P3_005N, asian = P3_006N, pacific_islander = P3_007N,
+    other = P3_008N, multiple_races = P3_009N
+  )]
 
-  p4_demographics <- fread(
-    p4_file_path,
-    header = FALSE, skip = 2,
-    select = c(1, 3, 4, 5),
-    col.names = c("GEO_ID", "total_population_p4", "hispanic", "non_hispanic")
-  )
+  p4_header <- names(fread(p4_file_path, nrows = 0))
+  p4_raw <- fread(p4_file_path, header = FALSE, skip = 2, col.names = p4_header)
+  p4_demographics <- p4_raw[, .(
+    GEO_ID, total_population_p4 = P4_001N, hispanic = P4_002N,
+    non_hispanic = P4_003N
+  )]
 
   block_demographics <- merge(p3_demographics, p4_demographics, by = "GEO_ID")
 

--- a/R/result_analysis/utility_functions/shape_extraction_functions.r
+++ b/R/result_analysis/utility_functions/shape_extraction_functions.r
@@ -271,6 +271,46 @@ assign_block_to_dominant_precinct <- function(county_precincts, county_blocks,
 }
 
 
+# read block-level P3 (race) and P4 (hispanic) redistricting tables and
+# combine them into one row-per-block demographic breakdown. Column
+# selections mirror python/solver/constants.py's CEN20_P3_*/CEN20_P4_*
+# (see python/solver/model_data.py's get_demographics_block for the
+# equivalent python-side computation) -- kept as a separate R
+# implementation rather than a reticulate bridge, since reticulate isn't
+# wired up for R-calls-Python anywhere in this project and the python
+# function is pandas/solver-specific.
+get_block_demographics <- function(p3_file_path, p4_file_path) {
+  p3_demographics <- fread(
+    p3_file_path,
+    header = FALSE, skip = 2,
+    select = c(1, 3, 5, 6, 7, 8, 9, 10, 11),
+    col.names = c(
+      "GEO_ID", "total_population", "white", "black", "native", "asian",
+      "pacific_islander", "other", "multiple_races"
+    )
+  )
+
+  p4_demographics <- fread(
+    p4_file_path,
+    header = FALSE, skip = 2,
+    select = c(1, 3, 4, 5),
+    col.names = c("GEO_ID", "total_population_p4", "hispanic", "non_hispanic")
+  )
+
+  block_demographics <- merge(p3_demographics, p4_demographics, by = "GEO_ID")
+
+  stopifnot(
+    "P3 and P4 total population disagree for at least one block" =
+      all(block_demographics$total_population == block_demographics$total_population_p4)
+  )
+
+  block_demographics[, total_population_p4 := NULL]
+  block_demographics[, GEOID20 := gsub("^1000000US", "", GEO_ID)]
+  block_demographics[, GEO_ID := NULL]
+
+  return(block_demographics)
+}
+
 write_to_file <- function(shape_data, location_folder, file_name) {
   # check if requisite folder exists, or create it
   shape_folder <- paste0(TIGER_FOLDER, "/", location_folder)

--- a/R/result_analysis/utility_functions/shape_extraction_functions.r
+++ b/R/result_analysis/utility_functions/shape_extraction_functions.r
@@ -311,6 +311,70 @@ get_block_demographics <- function(p3_file_path, p4_file_path) {
   return(block_demographics)
 }
 
+# join each populated census block to its assigned polling location's
+# driving distance, extend with demographic data, and flag blocks whose
+# distance exceeds distance_threshold_m. Granularity is the census block,
+# matching the native granularity of the driving-distances file.
+flag_distant_blocks <- function(block_precinct_assignment, block_demographics,
+                                driving_distances_file, potential_locations_file,
+                                distance_threshold_m) {
+  populated_blocks <- data.table(st_drop_geometry(block_precinct_assignment))
+  # TODO: revisit once #283 (precinct 73's zero-population bug) is
+  # resolved -- some genuinely-populated blocks may currently show
+  # total_population == 0 due to that bug, and would be dropped here
+  # incorrectly.
+  populated_blocks <- populated_blocks[total_population > 0]
+
+  potential_locations <- fread(potential_locations_file)
+  potential_locations[, USER_POLL_ := toupper(Location)]
+
+  # Step 5 of extract_precincts.r (reconciled_state_precinct_data(), via
+  # match_location_names()) already errors on any USER_POLL_ that doesn't
+  # case-insensitively match the county-provided file. If the stopifnot
+  # below ever fires, Step 5's reconciliation and potential_locations.csv
+  # have gone out of sync with each other -- that's an unexpected state
+  # worth investigating directly, not a case to silently drop or guess at.
+  resolved_blocks <- merge(
+    populated_blocks, potential_locations[, .(USER_POLL_, Location)],
+    by = "USER_POLL_"
+  )
+  stopifnot(
+    "Some populated blocks' USER_POLL_ did not match any potential_locations.csv Location" =
+      nrow(resolved_blocks) == nrow(populated_blocks)
+  )
+
+  driving_distances <- fread(driving_distances_file)
+  driving_distances[, id_orig := as.character(id_orig)]
+
+  distance_blocks <- merge(
+    resolved_blocks, driving_distances,
+    by.x = c("GEOID20", "Location"), by.y = c("id_orig", "id_dest")
+  )
+
+  # drop block_demographics' total_population before merging -- it's the
+  # same figure already carried on distance_blocks (both trace back to the
+  # same P3 total-population column), keeping it on both sides would
+  # produce ambiguous total_population.x/total_population.y columns.
+  demographic_columns <- setdiff(names(block_demographics), c("GEOID20", "total_population"))
+  demographic_blocks <- merge(
+    distance_blocks, block_demographics[, c("GEOID20", demographic_columns), with = FALSE],
+    by = "GEOID20"
+  )
+
+  demographic_blocks[, Weighted_dist := total_population * distance_m]
+  demographic_blocks[, flagged_distance := distance_m > distance_threshold_m]
+
+  setnames(demographic_blocks, c("GEOID20", "Location"), c("id_orig", "id_dest"))
+  output_columns <- c(
+    "id_orig", "id_dest", "distance_m", "Precinct_I", "total_population",
+    "white", "black", "native", "asian", "pacific_islander", "other",
+    "multiple_races", "hispanic", "non_hispanic", "Weighted_dist", "flagged_distance"
+  )
+  demographic_blocks <- demographic_blocks[, ..output_columns]
+
+  return(demographic_blocks)
+}
+
 write_to_file <- function(shape_data, location_folder, file_name) {
   # check if requisite folder exists, or create it
   shape_folder <- paste0(TIGER_FOLDER, "/", location_folder)

--- a/R/result_analysis/utility_functions/shape_extraction_functions.r
+++ b/R/result_analysis/utility_functions/shape_extraction_functions.r
@@ -295,20 +295,15 @@ assign_block_to_dominant_precinct <- function(county_precincts, county_blocks,
 
 
 # read block-level P3 (race) and P4 (hispanic) redistricting tables and
-# combine them into one row-per-block demographic breakdown. Column
-# selections mirror python/solver/constants.py's CEN20_P3_*/CEN20_P4_*
-# (see python/solver/model_data.py's get_demographics_block for the
-# equivalent python-side computation) -- kept as a separate R
-# implementation rather than a reticulate bridge, since reticulate isn't
-# wired up for R-calls-Python anywhere in this project and the python
-# function is pandas/solver-specific.
+# combine them into one row-per-block demographic breakdown. Output to 
+# mirror the demographic information represented in the *_results.csv 
+# solver outputs.
 get_block_demographics <- function(p3_file_path, p4_file_path) {
-  # row 1 holds the real census column codes (GEO_ID, NAME, P3_001N, ...);
-  # row 2 holds long descriptive labels; data starts at row 3. Read row 1
-  # as the header, then re-read the data with those names attached, so
-  # columns below are selected by their actual census code (matching
-  # python/solver/constants.py's CEN20_P3_*/CEN20_P4_*) rather than by
-  # position.
+  
+  ###Read P3 and P4 data #####
+  # row 1 holds the real census column codes (GEO_ID, NAME, P3_001N, ...) <- keep;
+  # row 2 holds long descriptive labels <- drop; 
+  # data starts at row 3. 
   p3_header <- names(fread(p3_file_path, nrows = 0))
   p3_raw <- fread(p3_file_path, header = FALSE, skip = 2, col.names = p3_header)
   p3_demographics <- p3_raw[, .(
@@ -324,27 +319,31 @@ get_block_demographics <- function(p3_file_path, p4_file_path) {
     non_hispanic = P4_003N
   )]
 
+  #### Merge by block to get all desired demographics
   block_demographics <- merge(p3_demographics, p4_demographics, by = "GEO_ID")
 
+  ### Check that the populations match (i.e. that the tables are both pulled for the same data)
   stopifnot(
     "P3 and P4 total population disagree for at least one block" =
       all(block_demographics$total_population == block_demographics$total_population_p4)
   )
 
-  block_demographics[, total_population_p4 := NULL]
-  block_demographics[, GEOID20 := gsub("^1000000US", "", GEO_ID)]
-  block_demographics[, GEO_ID := NULL]
+  #clean columns
+  block_demographics[, total_population_p4 := NULL
+                ][, GEOID20 := gsub("^1000000US", "", GEO_ID)
+                ][, GEO_ID := NULL]
 
   return(block_demographics)
 }
 
 # join each populated census block to its assigned polling location's
 # driving distance, extend with demographic data, and flag blocks whose
-# distance exceeds distance_threshold_m. Granularity is the census block,
-# matching the native granularity of the driving-distances file.
+# distance exceeds distance_threshold_m. 
 flag_distant_blocks <- function(block_precinct_assignment, block_demographics,
                                 driving_distances_file, potential_locations_file,
                                 distance_threshold_m) {
+  #drop geometry. Make a data.table 
+  #Recall, block_precinct_assignment is based off (potentially modified) state data
   populated_blocks <- data.table(st_drop_geometry(block_precinct_assignment))
   # TODO: revisit once #283 (precinct 73's zero-population bug) is
   # resolved -- some genuinely-populated blocks may currently show
@@ -352,61 +351,58 @@ flag_distant_blocks <- function(block_precinct_assignment, block_demographics,
   # incorrectly.
   populated_blocks <- populated_blocks[total_population > 0]
 
+  # data with polling location coordinates
+  # clean to match block precinct assignment
   potential_locations <- fread(potential_locations_file)
   potential_locations[, USER_POLL_ := toupper(Location)]
 
-  # Agreement between USER_POLL_ and potential_locations.csv's Location
-  # column was established out-of-band by a one-off manual correction
-  # (scratch_correct_state_precinct_names.r) -- Step 5's
-  # match_location_names() only validates the county-provided precinct file
-  # against the state shapefile, it never checks potential_locations.csv.
-  # The stopifnot below is this pairing's real, active runtime guard: if it
-  # ever fires, potential_locations.csv and USER_POLL_ have gone out of
-  # sync -- an unexpected state worth investigating directly, not a case to
-  # silently drop or guess at.
+  # At this point USER_POLL_ in block assignment and potential_locations.csv's 
+  # Location columns should match (Step 5)
+  # If they don't error message flahs that they are out of sync.
   resolved_blocks <- merge(
     populated_blocks, potential_locations[, .(USER_POLL_, Location)],
     by = "USER_POLL_"
   )
   stopifnot(
-    "Populated blocks' USER_POLL_ and potential_locations.csv's Location did not match one-to-one -- either some USER_POLL_ values are missing from potential_locations.csv (rows dropped), or potential_locations.csv has duplicate Location values (rows multiplied)" =
+    "Populated blocks' USER_POLL_ and potential_locations.csv's Location did not match one-to-one 
+    check if the state provided file still matches data from potential_locations files" =
       nrow(resolved_blocks) == nrow(populated_blocks)
   )
 
   driving_distances <- fread(driving_distances_file)
   driving_distances[, id_orig := as.character(id_orig)]
 
+  #merge in driving distances
   distance_blocks <- merge(
     resolved_blocks, driving_distances,
     by.x = c("GEOID20", "Location"), by.y = c("id_orig", "id_dest")
   )
   stopifnot(
-    "Some resolved blocks' (GEOID20, Location) pair had no matching row in driving_distances_file -- driving_distances_file may be incomplete or out of sync with potential_locations.csv, or vice versa" =
+    "Some resolved blocks' (GEOID20, Location) pair had no matching row in driving_distances_file 
+    -- driving_distances_file may be incomplete or out of sync with potential_locations.csv, or vice versa" =
       nrow(distance_blocks) == nrow(resolved_blocks)
   )
 
-  # drop block_demographics' total_population before merging -- it's the
-  # same figure already carried on distance_blocks (both trace back to the
-  # same P3 total-population column), keeping it on both sides would
-  # produce ambiguous total_population.x/total_population.y columns.
+  # drop block_demographics' total_population (duplicate) before merging 
   demographic_columns <- setdiff(names(block_demographics), c("GEOID20", "total_population"))
   demographic_blocks <- merge(
     distance_blocks, block_demographics[, c("GEOID20", demographic_columns), with = FALSE],
     by = "GEOID20"
   )
   stopifnot(
-    "Some distance-joined blocks' GEOID20 had no matching row in block_demographics -- block_demographics may be incomplete or out of sync with the block/precinct assignment, or vice versa" =
+    "Some distance-joined blocks' GEOID20 had no matching row in block_demographics 
+    -- block_demographics may be incomplete or out of sync with the block/precinct assignment, or vice versa" =
       nrow(demographic_blocks) == nrow(distance_blocks)
   )
 
-  demographic_blocks[, Weighted_dist := total_population * distance_m]
+  demographic_blocks[, weighted_dist := total_population * distance_m]
   demographic_blocks[, flagged_distance := distance_m > distance_threshold_m]
 
   setnames(demographic_blocks, c("GEOID20", "Location"), c("id_orig", "id_dest"))
   output_columns <- c(
     "id_orig", "id_dest", "distance_m", "Precinct_I", "total_population",
     "white", "black", "native", "asian", "pacific_islander", "other",
-    "multiple_races", "hispanic", "non_hispanic", "Weighted_dist", "flagged_distance"
+    "multiple_races", "hispanic", "non_hispanic", "weighted_dist", "flagged_distance"
   )
   demographic_blocks <- demographic_blocks[, ..output_columns]
 


### PR DESCRIPTION
## Summary

- Adds Step 6 to `R/result_analysis/extract_precincts.r`: for each populated Monongalia census block, joins its driving distance to its assigned polling location, extends the row with demographic data (race/hispanic breakdown), and flags blocks over a 5-mile threshold.
- Adds two new reusable functions to `R/result_analysis/utility_functions/shape_extraction_functions.r`: `get_block_demographics()` (block-level P3/P4 census demographic breakdown) and `flag_distant_blocks()` (the join + flagging logic).
- Adds `DRIVING_DISTANCE_SUFFIX`/`DRIVING_DISTANCES_FILE` config constants to `Monongalia_County_WV.r`.
- Output: `precinct_analysis_outputs/Monongalia_County_WV/distance_flagged_blocks.csv` — 2071 populated blocks, 276 flagged as more than 5 miles (8046.72m, a named constant with a `TODO(#271)` pointer to the future drive-time replacement) from their assigned polling location.

Closes #269. Depends on #267/#268, both substantially implemented already on this branch (block→precinct assignment and polling-location name resolution were already in place; this PR reuses them rather than re-deriving them).

## Test plan

- [x] Column positions for P3 (race) and P4 (hispanic) census tables verified against real Monongalia data before implementation (race columns sum to `total_population` for all 2772 blocks; `hispanic + non_hispanic` sums to `total_population` for all 2772 blocks; P3/P4 totals agree for all 2772 blocks)
- [x] Full pipeline run end-to-end against real Monongalia data: 2071 populated blocks, 276 flagged, matching pre-validated ground truth
- [x] All 24 distinct polling-location names resolve cleanly (case-insensitive) between `USER_POLL_` and `potential_locations.csv`'s `Location` column — zero mismatches
- [x] `lintr::lint()` clean of new finding categories on both modified files (pre-existing findings unrelated to this change remain, per project convention)
- [x] No automated R test suite exists in this project (per `R/CLAUDE.md`) — verification is Rscript execution + manual inspection, as above
- [x] Two joins that could previously silently drop rows on mismatched future data are now guarded with `stopifnot`, independently verified to fire correctly against synthetic mismatched data during final review

🤖 Generated with [Claude Code](https://claude.com/claude-code)