### PR TITLE
fix(census): use underscores in TIGER state dir for multi-word state names

### DIFF
--- a/python/tests/pull_census_data_test.py
+++ b/python/tests/pull_census_data_test.py
@@ -107,6 +107,32 @@ class TestPullTigerFile:
         assert Path(captured['local_dir']) == expected
         assert Path(captured['unzip_outdir']) == expected
 
+    def test_multiword_state_name_uses_underscores_not_spaces(self):
+        """Multi-word state dirs use underscores (54_WEST_VIRGINIA), not spaces.
+
+        The Census TIGER server names the directory 54_WEST_VIRGINIA; a space
+        404s. Regression guard for every multi-word state (issue #303).
+        """
+        captured = {}
+
+        def fake_download(url, local_dir):
+            captured['url'] = url
+            return Path(local_dir) / 'fake.zip'
+
+        with patch('python.utils.pull_census_data.download_file', side_effect=fake_download), \
+             patch('python.utils.pull_census_data.unzip_file', return_value=None):
+            pull_tiger_file(
+                state='West Virginia',
+                fips='54',
+                county_st='Monongalia_County_WV',
+                county_code='061',
+                geo=BLOCK_GEO,
+                census_year='2020',
+            )
+
+        assert '54_WEST_VIRGINIA' in captured['url']
+        assert '54_WEST VIRGINIA' not in captured['url']
+
 
 class TestRequestWithRetries:
     """Tests for _request_with_retries()."""

--- a/python/utils/pull_census_data.py
+++ b/python/utils/pull_census_data.py
@@ -430,7 +430,7 @@ def pull_tiger_file(state, fips, county_st, county_code, geo, census_year, verbo
 
     base_url = (
         f'https://www2.census.gov/geo/tiger/TIGER{census_year}PL'
-        f'/STATE/{fips}_{state.upper()}/{fips}{county_code}'
+        f'/STATE/{fips}_{state.upper().replace(" ", "_")}/{fips}{county_code}'
         f'/tl_{census_year}_{fips}{county_code}_{geo_suffix}.zip'
     )
     output_directory = Path(build_tiger_location_dir(county_st))


### PR DESCRIPTION
Fixes the Census TIGER download for multi-word state names — see #303.

## Problem

`pull_tiger_file` built the TIGER URL as `.../STATE/{fips}_{state.upper()}/...`, leaving spaces in multi-word state names. West Virginia → `54_WEST VIRGINIA`, but the Census server names the directory `54_WEST_VIRGINIA`, so the download 404'd. This broke census pulls for **every** multi-word state (WV, NY, NJ, NM, NH, North/South Carolina/Dakota, Rhode Island, DC…). It went unnoticed because every county pulled so far is in a single-word state (TX, VA, SC, GA, WI). Surfaced pulling **Monongalia County WV** for the driving-time epic (#227).

## Fix

`state.upper().replace(" ", "_")` in the state-directory segment. Tested through `pull_tiger_file`'s existing `download_file`-mock pattern (no new helper needed) — the test asserts the built URL contains `54_WEST_VIRGINIA`, not a space. TDD: confirmed the test fails on the old URL first.

## Notes

- Single-line behavior change; the P3/P4 redistricting URLs are unaffected (only the TIGER URL embeds the state name this way).
- `pull_census_data.py` carries a **pre-existing** pylint `E1136` at line 327 (`Value 'data' is unsubscriptable`) in an unrelated function — left untouched, out of scope for this focused fix.

Closes #303. Base: `feature/driving-time-metric` (epic #227).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
