### PR TITLE
fix(scripts): validate config_name matches yaml filename (#214)

### DIFF
--- a/python/scripts/model_run_cli.py
+++ b/python/scripts/model_run_cli.py
@@ -61,6 +61,13 @@ def load_configs(config_paths: list[str], logdir: str) -> tuple[bool, list[Polli
             print(f'Config folder "{config_folder}" name does not match config_set field "{config.config_set}" for config file {config_abs_path}')
             valid = False
 
+        # Return invalid if the config_name does not match the config's filename stem (case insensitive)
+        config_file_stem = os.path.splitext(os.path.basename(config_abs_path))[0]
+        if config and config_file_stem.upper() != config.config_name.upper():
+            print(f'Config filename stem "{config_file_stem}" does not match config_name field '
+                  f'"{config.config_name}" for config file {config_abs_path}')
+            valid = False
+
     return (valid, results)
 
 

--- a/python/tests/model_run_cli_test.py
+++ b/python/tests/model_run_cli_test.py
@@ -1,0 +1,53 @@
+''' Tests for python.scripts.model_run_cli.load_configs. '''
+
+from pathlib import Path
+
+from python.scripts.model_run_cli import load_configs
+
+
+def _write_config(config_dir: Path, filename: str, config_set: str, config_name: str) -> Path:
+    ''' Write a known-good testing config to config_dir/filename with the given
+    config_set and config_name, and return its path. '''
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / filename
+    config_path.write_text(
+        f'config_set: {config_set}\n'
+        f'config_name: {config_name}\n'
+        'location: testing\n'
+        'census_year: 2020\n'
+        'year:\n'
+        "    - '2020'\n"
+        'bad_types:\n'
+        "    - 'bg_centroid'\n"
+        'beta: -2\n'
+        'time_limit: 360000\n'
+        'limits_gap: 0.0\n'
+        'capacity: 5\n'
+        'fixed_capacity_site_number: null\n'
+        'precincts_open: 3\n'
+        'max_min_mult: 5\n'
+        'maxpctnew: 1\n'
+        'minpctold: .5\n',
+        encoding='utf-8',
+    )
+    return config_path
+
+
+def test_config_name_mismatch_is_invalid(tmp_path):
+    ''' A config whose config_name differs from its filename stem is rejected. '''
+    config_dir = tmp_path / 'testing'
+    config_path = _write_config(config_dir, 'mismatch.yaml', 'testing', 'something_else')
+
+    valid, unused_configs = load_configs([str(config_path)], str(tmp_path))
+
+    assert valid is False
+
+
+def test_config_name_case_only_difference_is_valid(tmp_path):
+    ''' A config_name that matches the filename stem apart from case is accepted. '''
+    config_dir = tmp_path / 'testing'
+    config_path = _write_config(config_dir, 'Foo.yaml', 'testing', 'foo')
+
+    valid, unused_configs = load_configs([str(config_path)], str(tmp_path))
+
+    assert valid is True


### PR DESCRIPTION
## Summary

`load_configs()` in `python/scripts/model_run_cli.py` validated that a config file's *folder* matched its `config_set` field, but never checked that the `config_name` field matched the YAML *filename stem*. Because output filenames are built from `config_name` (`python/solver/model_run.py:236` → `file_prefix = f'{config_set}.{config_name}'`, and `model_run.py:145` → `run_prefix = f'{config_set}/{config_name}'`), a config copied from another with a stale `config_name` would silently write results under the **other** config's name — and could overwrite them — with no warning.

This adds a validation that mirrors the existing `config_set`/folder check in the same function: on a mismatch between the filename stem and `config_name`, it prints a clear message and marks the batch invalid (collect-and-continue; `main()` then exits non-zero). It is guarded by `if config` so that a parse failure surfaces its own error rather than being masked by this one.

## Case-insensitive — deliberate divergence (please note)

The comparison is **case-insensitive** (`stem.upper() != config.config_name.upper()`), matching the sibling `config_set` check in the same function. This **intentionally diverges** from `python/scripts/auto_generate_config.py:117-120`, which does a stricter case-**sensitive** `config_name`-vs-filename check that raises.

Rationale: a real clobber differs by whole words, not just case, so case-insensitive catches 100% of the actual overwrite risk while tolerating only cosmetic case drift (which can never collide with a *different* config). Flagging this explicitly so it is not later read as an oversight — happy to make it case-sensitive to match `auto_generate_config` if reviewers prefer consistency there.

## Scope

- Only `model_run_cli.py` (the CSV path).
- `model_run_db_cli.py` is intentionally **unchanged** — the DB CLI loads configs from BigQuery by `config_set`/`config_name`, so there is no filename to validate.

## Tests

- New `python/tests/model_run_cli_test.py` unit-tests `load_configs` directly (TDD, red-first):
  - mismatched `config_name` vs filename stem → `valid is False`
  - case-only difference (`Foo.yaml` / `config_name: foo`) → `valid is True` (proves the check is case-insensitive)
- Full suite: **198 passed, 19 skipped** (DB e2e tests, no `settings.yaml` in this environment).
- Backward-compatibility scan: all **80** committed configs under `datasets/configs/` already satisfy the new check — none would be newly rejected.

Issue: #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)
