### PR TITLE
feat(r): metric-aware graphs, maps, and regressions (#231)

### DIFF
--- a/R/result_analysis/Basic_analysis.r
+++ b/R/result_analysis/Basic_analysis.r
@@ -258,4 +258,4 @@ sapply(orig_list_prepped, function(x)make_demo_dist_map(x, 'asian'))
 sapply(orig_list_block_prepped, function(x)make_precinct_map_no_people(x))
 sapply(orig_list_block_prepped, function(x)make_precinct_map(x))
 
-#upload_graph_files_to_cloud_storage()
+upload_graph_files_to_cloud_storage()

--- a/R/result_analysis/Basic_analysis.r
+++ b/R/result_analysis/Basic_analysis.r
@@ -50,6 +50,8 @@ source('R/result_analysis/utility_functions/regression_functions.R')
 ###
 source('R/result_analysis/Basic_analysis_configs/Monongalia_County_original_driving.r')
 
+#source('R/result_analysis/Basic_analysis_configs/Monongalia_County_original_driving_for_test.r')
+
 #source('R/result_analysis/Basic_analysis_configs/Dougherty_County_original_and_log.r')
 
 #######
@@ -83,6 +85,29 @@ orig_output_df_list <- read_result_data(orig_config_dt, field_of_interest = ORIG
 potential_output_df_list <- read_result_data(potential_config_dt, field_of_interest = POTENTIAL_FIELD_OF_INTEREST, 
 descriptor_dict = DESCRIPTOR_DICT_POTENTIAL)
 
+#########
+#Decide, once, whether each folder -- and the orig+potential combination,
+#if there is one -- has a single, consistent distance/time unit. Plots
+#that need one unit for their whole y-axis are gated on these below.
+#Maps and plot_density_v_distance_bg are not gated: they handle a mix of
+#units correctly by splitting, and don't consume these checks.
+#########
+
+orig_flag_strs <- resolve_flag_strs(orig_output_df_list$edes, 'orig_data', DRIVING_FLAG)
+
+potential_flag_strs <- if (!is.null(potential_output_df_list)) {
+	resolve_flag_strs(potential_output_df_list$edes, 'potential_data', DRIVING_FLAG)
+} else {
+	NULL
+}
+
+combined_flag_strs <- if (!is.null(orig_flag_strs) && !is.null(potential_flag_strs)) {
+	resolve_combined_flag_strs(
+		c(unique(orig_output_df_list$edes$metric), unique(potential_output_df_list$edes$metric)),
+		'orig_and_potential_combined', DRIVING_FLAG)
+} else {
+	NULL
+}
 
 #########
 #Set up maps
@@ -133,29 +158,39 @@ if(!HISTORICAL_FLAG){
 
     ###graphs####
 
-    #Add percent population to data ede data for graph scaling for all general config folder and orig
-    orig_pop_scaled_edes <- ede_with_pop(orig_output_df_list)
-    potential_pop_scaled_edes <- ede_with_pop(potential_output_df_list)
+    #Make the graphs that require the potential data to have a unique unit
 
-    #Plot the edes for all runs in config_folder by demographic and population only
-    plot_poll_edes(potential_output_df_list$edes)
-    plot_population_edes(potential_output_df_list$edes)
+    if (!is.null(potential_flag_strs)) {
+        #Plot the edes for all runs in config_folder by demographic and population only
+        plot_poll_edes(potential_output_df_list$edes, potential_flag_strs)
+        plot_population_edes(potential_output_df_list$edes, potential_flag_strs)
 
-    #Plot the edes for all runs in original_location and equivalent optimization runs by demographic
-    plot_original_optimized(potential_output_df_list$edes, orig_output_df_list$edes)
-    plot_original_optimized(potential_pop_scaled_edes, orig_pop_scaled_edes, '_scaled')
+        #Boxplots of the average distances traveled and the y_edes at each run in folder
+        plot_boxplots(potential_output_df_list$residence_distances, potential_flag_strs)
+    }
+
+    #Make the graphs that require the combined potential and original data to have a unique unit
+
+    if (!is.null(combined_flag_strs)) {
+        #Add percent population to data ede data for graph scaling for all general config folder and orig
+        orig_pop_scaled_edes <- ede_with_pop(orig_output_df_list)
+        potential_pop_scaled_edes <- ede_with_pop(potential_output_df_list)
+
+        #Plot the edes for all runs in original_location and equivalent optimization runs by demographic
+        plot_original_optimized(potential_output_df_list$edes, orig_output_df_list$edes, combined_flag_strs)
+        plot_original_optimized(potential_pop_scaled_edes, orig_pop_scaled_edes, combined_flag_strs, '_scaled')
+ 
+        #Histogram of the original distributions and that for the desired number of polls
+        plot_orig_ideal_hist(orig_output_df_list$residence_distances, potential_output_df_list$residence_distances, IDEAL_POLL_NUMBER, combined_flag_strs)
+
+        #Histograms of the original distributions by race and that for the desired number of polls
+        plot_original_optimized_demographic_hists(potential_output_df_list$residence_distances, orig_output_df_list$residence_distances, DEMOGRAPHIC_LIST, combined_flag_strs)
+    }
+
+    #Make the graphs that do not require a unique unit
 
     #Plot which precincts are used for each number of polls
     plot_precinct_persistence(potential_output_df_list$precinct_distances)
-
-    #Boxplots of the average distances traveled and the y_edes at each run in folder
-    plot_boxplots(potential_output_df_list$residence_distances)
-
-    #Histogram of the original distributions and that for the desired number of polls
-    #plot_orig_ideal_hist(orig_output_df_list$residence_distances, potential_output_df_list$residence_distances, IDEAL_POLL_NUMBER)
-
-    #Histograms of the original distributions by race and that for the desired number of polls
-    #plot_original_optimized_demographic_hists(potential_output_df_list$residence_distances, orig_output_df_list$residence_distances)
 
     #plot distance v density graphs and regressions
     plot_density_v_distance_bg(rbindlist(potential_bg_density_demo), LOCATION, DEMOGRAPHIC_LIST)
@@ -165,6 +200,8 @@ if(!HISTORICAL_FLAG){
 
     ###maps####
 
+    #maps don't need a unique unit
+    
     sapply(potential_list_prepped, function(x)make_bg_maps(x))
     sapply(potential_list_prepped, function(x)make_demo_dist_map(x, 'population'))
     sapply(potential_list_prepped, function(x)make_demo_dist_map(x, 'black'))
@@ -188,14 +225,31 @@ setwd(file.path(here(), plot_folder))
 
 ###historic edes####
 
-#Plot the edes for all runs in historical data (original_config)
-plot_historic_edes(orig_output_df_list$edes)
-orig_pop_scaled_edes <- ede_with_pop(orig_output_df_list)
-plot_historic_edes(orig_pop_scaled_edes, '_scaled')
+#Make the graphs that require the potential data to have a unique unit
 
+if (!is.null(orig_flag_strs)) {
+    #Plot the edes for all runs in historical data (original_config)
+    plot_historic_edes(orig_output_df_list$edes, orig_flag_strs)
+    orig_pop_scaled_edes <- ede_with_pop(orig_output_df_list)
+    plot_historic_edes(orig_pop_scaled_edes, orig_flag_strs,'_scaled')
+}
+
+#Make the graphs that do not require a unique unit
+
+#plot distance v density graphs and regressions
 plot_population_densities(orig_regression_data)
 
+#Plot which precincts are used for each number of polls
+plot_precinct_persistence(orig_output_df_list$precinct_distances)
+
+#plot distance v density graphs and regressions
+plot_density_v_distance_bg(rbindlist(orig_bg_density_demo), LOCATION, DEMOGRAPHIC_LIST)
+orig_bg_coefs <- bg_level_naive_regression(rbindlist(orig_bg_density_demo))
+
+
 ###maps####
+
+#maps don't need a unique unit
 sapply(orig_list_prepped, function(x)make_bg_maps(x))
 
 sapply(orig_list_prepped, function(x)make_demo_dist_map(x, 'population'))
@@ -206,10 +260,4 @@ sapply(orig_list_prepped, function(x)make_demo_dist_map(x, 'asian'))
 sapply(orig_list_block_prepped, function(x)make_precinct_map_no_people(x))
 sapply(orig_list_block_prepped, function(x)make_precinct_map(x))
 
-#plot distance v density graphs and regressions
-
-plot_density_v_distance_bg(rbindlist(orig_bg_density_demo), LOCATION, DEMOGRAPHIC_LIST)
-
-orig_bg_coefs <- bg_level_naive_regression(rbindlist(orig_bg_density_demo))
-
-upload_graph_files_to_cloud_storage()
+#upload_graph_files_to_cloud_storage()

--- a/R/result_analysis/Basic_analysis.r
+++ b/R/result_analysis/Basic_analysis.r
@@ -50,8 +50,6 @@ source('R/result_analysis/utility_functions/regression_functions.R')
 ###
 source('R/result_analysis/Basic_analysis_configs/Monongalia_County_original_driving.r')
 
-#source('R/result_analysis/Basic_analysis_configs/Monongalia_County_original_driving_for_test.r')
-
 #source('R/result_analysis/Basic_analysis_configs/Dougherty_County_original_and_log.r')
 
 #######

--- a/R/result_analysis/Basic_analysis.r
+++ b/R/result_analysis/Basic_analysis.r
@@ -37,18 +37,18 @@ source('R/result_analysis/utility_functions/regression_functions.R')
 #     4. run 
 #######
 
-args = commandArgs(trailingOnly = TRUE)
-if (length(args) != 1){
-     stop("Must enter exactly one config file") 
-    } else{#read constants from indicated config file
-    config_path <- paste0('R/result_analysis/Basic_analysis_configs/', args[1])
-    source(config_path)
-}
+#args = commandArgs(trailingOnly = TRUE)
+#if (length(args) != 1){
+#     stop("Must enter exactly one config file") 
+#    } else{#read constants from indicated config file
+#    config_path <- paste0('R/result_analysis/Basic_analysis_configs/', args[1])
+#    source(config_path)
+#}
 
 ###
 #For inline testing only
 ###
-#source('R/result_analysis/Basic_analysis_configs/Bartow_County_original.r')
+source('R/result_analysis/Basic_analysis_configs/Monongalia_County_original_driving.r')
 
 #source('R/result_analysis/Basic_analysis_configs/Dougherty_County_original_and_log.r')
 
@@ -66,7 +66,6 @@ config_dt_list<-c(orig_config_dt, potential_config_dt)
 
 #get driving flags
 DRIVING_FLAG <- set_global_flag(config_dt_list, 'driving')
-LOG_FLAG <- set_global_flag(config_dt_list, 'log_distance')
 
 
 #######

--- a/R/result_analysis/Basic_analysis_configs/Monongalia_County_original_driving.r
+++ b/R/result_analysis/Basic_analysis_configs/Monongalia_County_original_driving.r
@@ -1,0 +1,68 @@
+#######
+#Analysis Constants
+#######
+
+#Basic constants for analysis
+#LOCATION must be either a string or list of strings
+#ORIG_CONFIG_FOLDER must be a string
+#POTENTIAL_CONFIG_FOLDER must either be a string or NULL
+#                   NULL indicates that this set of constants is only 
+#                   on for historical
+
+
+LOCATION = 'Monongalia_County_WV' #needed only for reading from csv and writing outputs
+ORIG_CONFIG_FOLDER = "Monongalia_County_WV_driving_original_configs"
+POTENTIAL_CONFIG_FOLDER = NULL #leave NULL if only want historical analysis
+ORIG_FIELD_OF_INTEREST = '' #must not leave empty if config set has only one element
+POTENTIAL_FIELD_OF_INTEREST = '' #must not leave empty if config set has only one element
+
+if (is.null(POTENTIAL_CONFIG_FOLDER)){
+    HISTORICAL_FLAG = TRUE
+}else{HISTORICAL_FLAG = FALSE}
+
+DEMOGRAPHIC_LIST = c('white', 'black')
+
+#Run-type specific constants
+IDEAL_POLL_NUMBER  = 17 #the optimal number of polls desired for this county
+
+#dictionary of custom descriptors
+#keys: automatatically generated descriptor values to change
+#values: the desired descriptor values
+#eg
+#DESCRIPTOR_DICT_ORIG <- c('year_2014' = '2014', 'year_2016' = '2016', 
+                     #'year_2018' = '2018', 'year_2020' = '2020', 
+                     #'year_2022' = '2022')
+#If no changes desired, set 
+DESCRIPTOR_DICT_ORIG <-NULL
+DESCRIPTOR_DICT_POTENTIAL <- NULL
+
+
+#######
+#Constants for DB
+#######
+
+# This is where this analysis will be stored in the cloud
+STORAGE_BUCKET = 'equitable-polling-analysis'
+if (HISTORICAL_FLAG){
+    CLOUD_STORAGE_ANALYSIS_NAME = paste(ORIG_CONFIG_FOLDER, 'HISTORICAL')
+}else{
+    CLOUD_STORAGE_ANALYSIS_NAME = paste0(ORIG_CONFIG_FOLDER, '_AND_', POTENTIAL_CONFIG_FOLDER)
+}
+
+#constants for reading data
+READ_FROM_CSV = FALSE
+PRINT_SQL = FALSE
+
+#constants for database queries
+#only need to define if READ_FROM_CSV = FALSE
+PROJECT = "equitable-polling-locations"
+DATASET = "equitable_polling_locations_prod"
+BILLING = PROJECT
+
+#Connect to database if needed
+#returns NULL if READ_FROM_CSV = TRUE
+POLLING_CON <- define_connection()
+
+
+#constants for how graphs and maps should be made
+LINEAR_COLOR_GRADIENT = FALSE #should the maps have a log or linear color scale

--- a/R/result_analysis/Basic_analysis_configs/Monongalia_County_original_driving.r
+++ b/R/result_analysis/Basic_analysis_configs/Monongalia_County_original_driving.r
@@ -50,7 +50,7 @@ if (HISTORICAL_FLAG){
 }
 
 #constants for reading data
-READ_FROM_CSV = FALSE
+READ_FROM_CSV = TRUE
 PRINT_SQL = FALSE
 
 #constants for database queries

--- a/R/result_analysis/Basic_analysis_configs/Monongalia_County_original_driving_for_test.r
+++ b/R/result_analysis/Basic_analysis_configs/Monongalia_County_original_driving_for_test.r
@@ -1,0 +1,68 @@
+#######
+#Analysis Constants
+#######
+
+#Basic constants for analysis
+#LOCATION must be either a string or list of strings
+#ORIG_CONFIG_FOLDER must be a string
+#POTENTIAL_CONFIG_FOLDER must either be a string or NULL
+#                   NULL indicates that this set of constants is only 
+#                   on for historical
+
+
+LOCATION = 'Monongalia_County_WV' #needed only for reading from csv and writing outputs
+ORIG_CONFIG_FOLDER = "Monongalia_County_WV_driving_original_configs"
+POTENTIAL_CONFIG_FOLDER = "Monongalia_County_WV_driving_original_configs" #leave NULL if only want historical analysis
+ORIG_FIELD_OF_INTEREST = '' #must not leave empty if config set has only one element
+POTENTIAL_FIELD_OF_INTEREST = '' #must not leave empty if config set has only one element
+
+if (is.null(POTENTIAL_CONFIG_FOLDER)){
+    HISTORICAL_FLAG = TRUE
+}else{HISTORICAL_FLAG = FALSE}
+
+DEMOGRAPHIC_LIST = c('white', 'black')
+
+#Run-type specific constants
+IDEAL_POLL_NUMBER  = 17 #the optimal number of polls desired for this county
+
+#dictionary of custom descriptors
+#keys: automatatically generated descriptor values to change
+#values: the desired descriptor values
+#eg
+#DESCRIPTOR_DICT_ORIG <- c('year_2014' = '2014', 'year_2016' = '2016', 
+                     #'year_2018' = '2018', 'year_2020' = '2020', 
+                     #'year_2022' = '2022')
+#If no changes desired, set 
+DESCRIPTOR_DICT_ORIG <-NULL
+DESCRIPTOR_DICT_POTENTIAL <- NULL
+
+
+#######
+#Constants for DB
+#######
+
+# This is where this analysis will be stored in the cloud
+STORAGE_BUCKET = 'equitable-polling-analysis'
+if (HISTORICAL_FLAG){
+    CLOUD_STORAGE_ANALYSIS_NAME = paste(ORIG_CONFIG_FOLDER, 'HISTORICAL')
+}else{
+    CLOUD_STORAGE_ANALYSIS_NAME = paste0(ORIG_CONFIG_FOLDER, '_AND_', POTENTIAL_CONFIG_FOLDER)
+}
+
+#constants for reading data
+READ_FROM_CSV = TRUE
+PRINT_SQL = FALSE
+
+#constants for database queries
+#only need to define if READ_FROM_CSV = FALSE
+PROJECT = "equitable-polling-locations"
+DATASET = "equitable_polling_locations_prod"
+BILLING = PROJECT
+
+#Connect to database if needed
+#returns NULL if READ_FROM_CSV = TRUE
+POLLING_CON <- define_connection()
+
+
+#constants for how graphs and maps should be made
+LINEAR_COLOR_GRADIENT = FALSE #should the maps have a log or linear color scale

--- a/R/result_analysis/utility_functions/graph_functions.R
+++ b/R/result_analysis/utility_functions/graph_functions.R
@@ -690,19 +690,12 @@ plot_population_densities <- function(density_df){
 #at the block group level, ordered by population density
 #log / log scale, with best fit lines
 plot_density_v_distance_bg <- function(bg_density_data, county, demo_list, driving_flag = DRIVING_FLAG){
-	metric <- get_uniform_metric(bg_density_data, 'plot_density_v_distance_bg')
-	if (is.null(metric)) return(invisible(NULL))
-
-	#set graph y axis bounds. if min_distance == 0 m, make 1m
-	min_dist = min(bg_density_data[demographic %in% demo_list, ]$demo_avg_dist, na.rm = TRUE)
-	max_dist = max(bg_density_data[demographic %in% demo_list, ]$demo_avg_dist, na.rm = TRUE)
-	if (min_dist == 0){min_dist = min_dist + .01}
-    y_bounds = c(min_dist,max_dist)
-
 	#trim log density outliers
 	trimmed <- bg_density_data[abs(z_score_log_density)<4, ]
+	#tag each row with its metric's unit, so bounds can be computed per unit below
+	trimmed[, unit := sapply(metric, function(m) METRIC_LABELS[[m]]$unit)]
 
-    descriptor_graph <- function(descriptor_str, demo_list, y_bounds){   
+    descriptor_graph <- function(descriptor_str, demo_list, y_bounds, metric){
 		flag_strs <- make_flag_strs(driving_flag, metric)
 
 		title_str = paste0('Average', flag_strs$driving_str, flag_strs$word, ' to poll by demographic and block group')
@@ -719,7 +712,21 @@ plot_density_v_distance_bg <- function(bg_density_data, county, demo_list, drivi
 		add_graph_to_graph_file_manifest(graph_file_path)
 		ggsave(graph_file_path)
     }
-    descriptors = unique(trimmed$descriptor)
-    sapply(descriptors, function(x){descriptor_graph(x, demo_list, y_bounds)})
+
+	#set graph y axis bounds per unit (apples-to-apples within a unit;
+	#if min_distance == 0, make it .01 so log scale doesn't break)
+	plot_unit_group <- function(unit_data){
+		this_metric <- unit_data$metric[1]
+		demo_filtered <- unit_data[demographic %in% demo_list, ]
+		min_dist <- min(demo_filtered$demo_avg_dist, na.rm = TRUE)
+		max_dist <- max(demo_filtered$demo_avg_dist, na.rm = TRUE)
+		if (min_dist == 0){min_dist <- min_dist + .01}
+		y_bounds <- c(min_dist, max_dist)
+
+		descriptors <- unique(unit_data$descriptor)
+		sapply(descriptors, function(x){descriptor_graph(x, demo_list, y_bounds, this_metric)})
+	}
+
+	invisible(lapply(split(trimmed, trimmed$unit), plot_unit_group))
     }
 

--- a/R/result_analysis/utility_functions/graph_functions.R
+++ b/R/result_analysis/utility_functions/graph_functions.R
@@ -15,10 +15,11 @@ TABLES = c("edes", "precinct_distances", "residence_distances", "results")
 DEMO_COLS =  c("population", "hispanic","non_hispanic", "white", "black", "native", "asian", "pacific_islander", "other")
 
 PRINT_SQL = FALSE
-
-
-
-
+METRIC_LABELS <- list(
+	haversine        = list(word = 'distance', unit = 'm',   scale = 1),
+	driving_distance = list(word = 'distance', unit = 'm',   scale = 1),
+	driving_time     = list(word = 'time',     unit = 'min', scale = 1 / 60)
+)
 
 #########
 #Get flags from the config folders or config file
@@ -80,10 +81,22 @@ select_varying_fields <- function(config_dt){
 		stop(paste('Too many fields vary across collection of config files:', paste(varying_cols, collapse = ', ')))
 	}
 
-	#select the parameter of interest
-	result_dt <- config_dt_filtered[ , ..varying_cols]
+	#always carry metric through, whether or not it's the folder's one varying field
+	cols_to_keep <- union(varying_cols, 'metric')
+	result_dt <- config_dt_filtered[ , ..cols_to_keep]
 	return(result_dt)
 }
+
+scale_distance_columns <- function(dt, metric_labels = METRIC_LABELS){
+	#scale distance-bearing columns by the metric's unit 
+	scale_lookup <- sapply(metric_labels, function(x) x$scale)
+	distance_cols <- intersect(c('distance_m', 'weighted_dist', 'avg_dist', 'y_EDE'), names(dt))
+	if (length(distance_cols) > 0){
+		dt[ , (distance_cols) := lapply(.SD, function(x) x * scale_lookup[metric]), .SDcols = distance_cols]
+	}
+	return(dt)
+}
+
 
 create_descriptor_field <- function(config_dt, field_of_interest){
 	#1) identify the (unique) field that changes
@@ -111,8 +124,10 @@ create_descriptor_field <- function(config_dt, field_of_interest){
 	}
 
 	#2) create a descriptor field
-	#identify the field name
-	varying_field<- names(varying_dt)[names(varying_dt) != 'config_name']
+	#identify the field name; if metric is it, keep it. Else drop it.
+	varying_field <- setdiff(names(varying_dt), c('config_name', 'metric'))
+	if (length(varying_field) == 0){ varying_field <- 'metric' }
+
 	#paste the name of the varying field with its value
 	varying_dt <- varying_dt[, descriptor_pre:= varying_field
 						   ][, descriptor := do.call(paste, c(.SD, sep = '_')), .SDcols = c('descriptor_pre', varying_field)
@@ -266,7 +281,7 @@ assign_descriptor_to_result<- function(config_dt, result_type, field_of_interest
 	#read in descriptor data
 	vary_dt <- create_descriptor_field(config_dt, field_of_interest)
 	#drop varying field (because this changes across config_set)
-	vary_dt <- vary_dt [ , .(config_name, descriptor)]
+	vary_dt <- vary_dt [ , .(config_name, descriptor, metric)]
 	
 	
 	#read in output data
@@ -287,6 +302,9 @@ assign_descriptor_to_result<- function(config_dt, result_type, field_of_interest
 
 	#order the descriptor fields as factors
 	complete_dt <- order_descriptors(complete_dt)
+
+	#TODO: I don't like this here
+	complete_dt <- scale_distance_columns(complete_dt)
 
 	#fix data types (only needed for csv)
 	if ('id_dest' %in% names(complete_dt)){
@@ -340,14 +358,24 @@ demographic_legend_dict <- c(
 	'native' = 'First Nations',
 	'population' = 'Total')
 
-#helper function to make graph titles according to flag values
-make_flag_strs<- function(driving_flag, log_flag){
-	#make flag dependent labels
-	driving_str = ' straight line '
-	log_str = ''
-	if (driving_flag){driving_str = ' driving '} 
-	#if (log_flag){log_str = 'log '}
-	return(as.list(c(driving_str = driving_str, log_str = log_str)))
+#helper to guard plot functions against mixed-metric input data.
+get_uniform_metric <- function(df, plot_name, metric_labels = METRIC_LABELS){
+	metrics <- unique(df$metric)
+	units <- unique(sapply(metrics, function(m) metric_labels[[m]]$unit))
+	if (length(units) > 1){
+		warning(paste0(plot_name, ': skipped, data mixes units (', paste(metrics, collapse = ', '), ')'))
+		return(NULL)
+	}
+	return(metrics)
+}
+
+#helper function to make graph titles according to flag values and metric units
+make_flag_strs <- function(driving_flag, metric){
+	#make flag/metric dependent labels
+	driving_str <- ' straight line '
+	if (driving_flag){driving_str <- ' driving '}
+	metric_info <- METRIC_LABELS[[metric]]
+	return(as.list(c(driving_str = driving_str, word = metric_info$word, unit = metric_info$unit)))
 }
 
 #helper function to combine ede data from different config folders
@@ -389,12 +417,16 @@ ede_with_pop<- function(config_df_list){
 
 #makes a plot showing how y_EDEs change for each demographic group as the
 #number of polls is increased
-plot_poll_edes<-function(ede_df, driving_flag = DRIVING_FLAG, log_flag = LOG_FLAG){
+plot_poll_edes<-function(ede_df, driving_flag = DRIVING_FLAG){
+	#TODO: if (is.null(metric)) return(invisible(NULL)) 
+	#appears with every get_uniform_metric call. 
+	#can these be combined?
+	metric <- get_uniform_metric(ede_df, 'plot_poll_edes')
+	if (is.null(metric)) return(invisible(NULL))
+	flag_strs <- make_flag_strs(driving_flag, metric)
 
-	flag_strs <- make_flag_strs(driving_flag, log_flag)
-	
-	title_str = paste0('Equity weighted', flag_strs$driving_str, 'distance to poll by demographic')
-	y_str = paste0('Equity weighted', flag_strs$driving_str, 'distance (', flag_strs$log_str, 'm)')
+	title_str = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' to poll by demographic')
+	y_str = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' (', flag_strs$unit, ')')
 
 	graph = ggplot(ede_df, aes(x = descriptor, y = y_EDE,
 		group = demographic, color = demographic, shape = demographic)) +
@@ -411,11 +443,13 @@ plot_poll_edes<-function(ede_df, driving_flag = DRIVING_FLAG, log_flag = LOG_FLA
 
 #like plot_poll_edes, but plots just the y_edes for the
 # population as a whole, and not demographic groups
-plot_population_edes <- function(ede_df, driving_flag = DRIVING_FLAG, log_flag = LOG_FLAG){
-	flag_strs <- make_flag_strs(driving_flag, log_flag)
+plot_population_edes <- function(ede_df, driving_flag = DRIVING_FLAG){
+	metric <- get_uniform_metric(ede_df, 'plot_population_edes')
+	if (is.null(metric)) return(invisible(NULL))
+	flag_strs <- make_flag_strs(driving_flag, metric)
 
-	title_str = paste0('Equity weighted', flag_strs$driving_str, 'distance to poll')
-	y_str = paste0('Equity weighted', flag_strs$driving_str, 'distance (', flag_strs$log_str, 'm)')
+	title_str = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' to poll')
+	y_str = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' (', flag_strs$unit, ')')
 
 
 	graph = ggplot(ede_df[demographic == 'population', ], aes(x = descriptor, y = y_EDE))+
@@ -430,13 +464,17 @@ plot_population_edes <- function(ede_df, driving_flag = DRIVING_FLAG, log_flag =
 
 #makes a plot showing how the y_EDEs for multiple config_sets change 
 #as the number of polls is increased, for a specified demographic_group 
-plot_multiple_edes<-function(ede_list, demo_grp, driving_flag = DRIVING_FLAG, log_flag = LOG_FLAG){
+plot_multiple_edes<-function(ede_list, demo_grp, driving_flag = DRIVING_FLAG){
 	ede_df <- do.call(rbind, ede_list)
-
-	flag_strs <- make_flag_strs(driving_flag, log_flag)
 	
-	title_str = paste0('Equity weighted', flag_strs$driving_str, 'distance to poll by demographic')
-	y_str = paste0('Equity weighted', flag_strs$driving_str, 'distance (', flag_strs$log_str, 'm)')
+	metric <- get_uniform_metric(ede_df, 'plot_multiple_edes')	
+	if (is.null(metric)) return(invisible(NULL))
+
+	flag_strs <- make_flag_strs(driving_flag, metric)
+
+
+	title_str = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' to poll by demographic')
+	y_str = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' (', flag_strs$unit, ')')
 
 	ggplot(ede_df[demographic == demo_grp, ], aes(x = num_polls, y = y_EDE,
 		group = descriptor, color =  descriptor, shape = demo_grp)) +
@@ -455,7 +493,7 @@ plot_multiple_edes<-function(ede_list, demo_grp, driving_flag = DRIVING_FLAG, lo
 
 #makes two plots, one showing the y_ede the other avg distance
 #showing how these variables change across the included runs
-plot_historic_edes <- function(orig_ede, suffix = '', driving_flag = DRIVING_FLAG, log_flag = LOG_FLAG){
+plot_historic_edes <- function(orig_ede, suffix = '', driving_flag = DRIVING_FLAG){
 
 	#set x axis label order
 	descriptor_order <- unique(orig_ede$descriptor)
@@ -469,12 +507,14 @@ plot_historic_edes <- function(orig_ede, suffix = '', driving_flag = DRIVING_FLA
 	#does data contain scaling data
 	scale_bool = 'pct_demo_population' %in% names(orig_ede)
 	
-	flag_strs <- make_flag_strs(driving_flag, log_flag)
+	metric <- get_uniform_metric(orig_ede, 'plot_historic_edes')
+	if (is.null(metric)) return(invisible(NULL))
+	flag_strs <- make_flag_strs(driving_flag, metric)
 
 	#labels for various types of data
-	y_EDE_label = paste0('Equity weighted', flag_strs$driving_str, 'distance (', flag_strs$log_str, 'm)')
-	y_avg_label = paste0('Average', flag_strs$driving_str, 'distance (', flag_strs$log_str, 'm)')
-	title_str = paste0(flag_strs$log_str, flag_strs$driving_str, 'distance by demographic and optimization run')
+	y_EDE_label = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' (', flag_strs$unit, ')')
+	y_avg_label = paste0('Average', flag_strs$driving_str, flag_strs$word, ' (', flag_strs$unit, ')')
+	title_str = paste0(flag_strs$driving_str, flag_strs$word, ' by demographic and optimization run')
 	#plot with y_EDE
 	y_EDE = ggplot(orig_ede, aes(x = descriptor, y = y_EDE,
 		group = demographic, color = demographic, shape = demographic))
@@ -519,14 +559,14 @@ plot_historic_edes <- function(orig_ede, suffix = '', driving_flag = DRIVING_FLA
 
 #compares optimized runs with historical runs having the same number of
 #polls (via plot_historical_edes)
-plot_original_optimized <- function(config_ede, orig_ede, suffix = '', driving_flag = DRIVING_FLAG, log_flag = LOG_FLAG){
+plot_original_optimized <- function(config_ede, orig_ede, suffix = '', driving_flag = DRIVING_FLAG){
 	#select the relevant optimized runs
 	orig_num_polls <- unique(orig_ede$num_polls)
 	config_num_polls <- unique(config_ede$num_polls)
 	optimization_num_polls<- max(intersect(orig_num_polls, config_num_polls))
 	optimized_run_dfs <- config_ede[num_polls == optimization_num_polls]
 	orig_and_optimal <- rbind(orig_ede, optimized_run_dfs)
-	plot_historic_edes(orig_and_optimal, paste0('and_optimal', suffix), driving_flag, log_flag)
+	plot_historic_edes(orig_and_optimal, paste0('and_optimal', suffix), driving_flag)
 
 }
 
@@ -557,17 +597,18 @@ plot_precinct_persistence <- function(precinct_df){
 }
 
 #make boxplots of the average distances traveled and the y_edes at each run
-plot_boxplots <- function(residence_df,log_flag = LOG_FLAG, driving_flag = DRIVING_FLAG){
-	flag_strs <- make_flag_strs(driving_flag, log_flag)
- 
+plot_boxplots <- function(residence_df, driving_flag = DRIVING_FLAG){
+	metric <- get_uniform_metric(residence_df, 'plot_boxplots')
+	if (is.null(metric)) return(invisible(NULL))
+	flag_strs <- make_flag_strs(driving_flag, metric)
+
 	res_pop <- residence_df[demographic == 'population',
 		]
 	#avg distance
 	ggplot(res_pop, aes(x = num_polls, y = avg_dist, group = descriptor)) +
 		stat_boxplot(geom = "errorbar", color = "#555555")+
 		geom_boxplot(outlier.shape = NA, fill = TABLEAU_COLORS[1], color = "#333333", alpha = 0.7) +
-		scale_y_log10(limits = c(500,10500)) +
-		labs(x = 'Number of polls', y = paste0("Avg",  flag_strs$driving_str, "distance (", flag_strs$log_str, ' m)'), title = "Boxplot of distances by run") +
+		labs(x = 'Number of polls', y = paste0("Avg",  flag_strs$driving_str, flag_strs$word, " (", flag_strs$unit, ')'), title = paste0("Boxplot of ", flag_strs$word, "s by run")) +
 		theme_tableau()
 
 	graph_file_path = 'avg_dist_distribution_boxplots.png'
@@ -576,18 +617,20 @@ plot_boxplots <- function(residence_df,log_flag = LOG_FLAG, driving_flag = DRIVI
 }
 
 #make histogram of the average distances traveled in the historical and ideal situations
-plot_orig_ideal_hist <- function(orig_residence_df, config_residence_df, ideal_num, log_flag = LOG_FLAG, driving_flag = DRIVING_FLAG){
-	flag_strs <- make_flag_strs(driving_flag, log_flag)
-
+plot_orig_ideal_hist <- function(orig_residence_df, config_residence_df, ideal_num, driving_flag = DRIVING_FLAG){
 	orig_residence_df <- orig_residence_df[demographic == 'population', ]
 	ideal_residence_df <- config_residence_df[demographic == 'population', ][num_polls == ideal_num, ]
 	res_pop_orig_and_ideal <- rbind( ideal_residence_df, orig_residence_df)
 
+	metric <- get_uniform_metric(res_pop_orig_and_ideal, 'plot_orig_ideal_hist')
+	if (is.null(metric)) return(invisible(NULL))
+	flag_strs <- make_flag_strs(driving_flag, metric)
+
 	#avg_distance
-	title_str = paste0('Distribution of distances traveled by people by year and optimization')
+	title_str = paste0('Distribution of ', flag_strs$word, 's traveled by people by year and optimization')
 	ggplot(res_pop_orig_and_ideal, aes(x = avg_dist, fill = descriptor)) +
 		geom_histogram(aes(weight = demo_pop), position = "dodge", alpha = 0.8)+
-		labs(x = paste0("Avg",  flag_strs$driving_str, "distance (", flag_strs$log_str, ' m)'), y = 'Number of people', title =  title_str, fill = 'Optimization Run') +
+		labs(x = paste0("Avg",  flag_strs$driving_str, flag_strs$word, " (", flag_strs$unit, ')'), y = 'Number of people', title =  title_str, fill = 'Optimization Run') +
 		scale_fill_tableau(labels = function(x) str_to_title(str_replace_all(x, '_', ' '))) +
 		theme_tableau()
 	graph_file_path = 'avg_dist_distribution_hist.png'
@@ -598,10 +641,10 @@ plot_orig_ideal_hist <- function(orig_residence_df, config_residence_df, ideal_n
 plot_demographic_hist<- function(df, demo, flag_strs){
 
 	y_str = paste0('Number of ', demo, ' people')
-	title_str = paste0('Distribution of distances traveled by ', demo, ' people by year and optimization')
+	title_str = paste0('Distribution of ', flag_strs$word, 's traveled by ', demo, ' people by year and optimization')
 	hist = ggplot(df[demographic == demo, ], aes(x = avg_dist, fill = descriptor)) +
 		geom_histogram(aes(weight = demo_pop), position = "dodge", alpha = 0.8)+
-		labs(x = paste0("Avg",  flag_strs$driving_str, "distance (", flag_strs$log_str, ' m)'), y = y_str, title =  title_str, fill = 'Optimization Run') + scale_x_continuous(transform = 'log') +
+		labs(x = paste0("Avg",  flag_strs$driving_str, flag_strs$word, " (", flag_strs$unit, ')'), y = y_str, title =  title_str, fill = 'Optimization Run') + scale_x_continuous(transform = 'log') +
 		scale_fill_tableau(labels = function(x) str_to_title(str_replace_all(x, '_', ' '))) +
 		theme_tableau()
 
@@ -611,8 +654,7 @@ plot_demographic_hist<- function(df, demo, flag_strs){
 	return(hist)
 }
 
-plot_original_optimized_demographic_hists <- function(config_residence_df, orig_residence_df, demographic_list = DEMOGRAPHIC_LIST, driving_flag = DRIVING_FLAG, log_flag = LOG_FLAG){
-	flag_strs <- make_flag_strs(driving_flag, log_flag)
+plot_original_optimized_demographic_hists <- function(config_residence_df, orig_residence_df, demographic_list = DEMOGRAPHIC_LIST, driving_flag = DRIVING_FLAG){
 
 	#select the relevant optimized runs
 	orig_num_polls <- unique(orig_residence_df$num_polls)
@@ -621,6 +663,10 @@ plot_original_optimized_demographic_hists <- function(config_residence_df, orig_
 	optimized_run_dfs <- config_residence_df[num_polls == optimization_num_polls]
 	orig_and_optimal <- rbind(orig_residence_df, optimized_run_dfs)
 	descriptor_list <- unique(orig_and_optimal$descriptor)
+
+	metric <- get_uniform_metric(orig_and_optimal, 'plot_original_optimized_demographic_hists')
+	if (is.null(metric)) return(invisible(NULL))
+	flag_strs <- make_flag_strs(driving_flag, metric)
 
 	demographic_hists = lapply(demographic_list, function(x)plot_demographic_hist(orig_and_optimal, x, flag_strs))
 }
@@ -643,8 +689,10 @@ plot_population_densities <- function(density_df){
 #plot of average distances traveled by demographic groups, aggregated 
 #at the block group level, ordered by population density
 #log / log scale, with best fit lines
-plot_density_v_distance_bg <- function(bg_density_data, county, demo_list, log_flag = LOG_FLAG, driving_flag = DRIVING_FLAG){
-	
+plot_density_v_distance_bg <- function(bg_density_data, county, demo_list, driving_flag = DRIVING_FLAG){
+	metric <- get_uniform_metric(bg_density_data, 'plot_density_v_distance_bg')
+	if (is.null(metric)) return(invisible(NULL))
+
 	#set graph y axis bounds. if min_distance == 0 m, make 1m
 	min_dist = min(bg_density_data[demographic %in% demo_list, ]$demo_avg_dist, na.rm = TRUE)
 	max_dist = max(bg_density_data[demographic %in% demo_list, ]$demo_avg_dist, na.rm = TRUE)
@@ -655,10 +703,10 @@ plot_density_v_distance_bg <- function(bg_density_data, county, demo_list, log_f
 	trimmed <- bg_density_data[abs(z_score_log_density)<4, ]
 
     descriptor_graph <- function(descriptor_str, demo_list, y_bounds){   
-		flag_strs <- make_flag_strs(driving_flag, log_flag)
-	
-		title_str = paste0('Average', flag_strs$driving_str, 'distance to poll by demographic and block group')
-		y_str = paste0(paste0("Avg",  flag_strs$driving_str, "distance (", flag_strs$log_str, ' m)'))
+		flag_strs <- make_flag_strs(driving_flag, metric)
+
+		title_str = paste0('Average', flag_strs$driving_str, flag_strs$word, ' to poll by demographic and block group')
+		y_str = paste0(paste0("Avg",  flag_strs$driving_str, flag_strs$word, " (", flag_strs$unit, ')'))
 
         ggplot(trimmed[descriptor == descriptor_str & demographic %in% demo_list, ] , aes(x = pop_density_km, y = demo_avg_dist, group = demographic, color = demographic)) +
             geom_point(alpha = .7, aes(size = demo_pop )) + geom_smooth(method=lm, mapping = aes(weight = demo_pop), se= FALSE) + scale_x_continuous(trans = 'log10') + scale_y_log10(limits = y_bounds) +

--- a/R/result_analysis/utility_functions/graph_functions.R
+++ b/R/result_analysis/utility_functions/graph_functions.R
@@ -358,24 +358,33 @@ demographic_legend_dict <- c(
 	'native' = 'First Nations',
 	'population' = 'Total')
 
-#helper to guard plot functions against mixed-metric input data.
-get_uniform_metric <- function(df, plot_name, metric_labels = METRIC_LABELS){
-	metrics <- unique(df$metric)
-	units <- unique(sapply(metrics, function(m) metric_labels[[m]]$unit))
-	if (length(units) > 1){
-		warning(paste0(plot_name, ': skipped, data mixes units (', paste(metrics, collapse = ', '), ')'))
-		return(NULL)
-	}
-	return(metrics)
-}
-
 #helper function to make graph titles according to flag values and metric units
-make_flag_strs <- function(driving_flag, metric){
+make_flag_strs <- function(driving_flag, metric, metric_labels = METRIC_LABELS){
 	#make flag/metric dependent labels
 	driving_str <- ' straight line '
 	if (driving_flag){driving_str <- ' driving '}
 	metric_info <- METRIC_LABELS[[metric]]
 	return(as.list(c(driving_str = driving_str, word = metric_info$word, unit = metric_info$unit)))
+}
+
+#helper to guard plot functions against mixed-metric input data.
+#and assign correct flag strings accordingly.
+resolve_flag_strs <- function(df, data_str, driving_flag, metric_labels = METRIC_LABELS){
+	
+	#first, get check if the data mixes units. 
+	metrics <- unique(df$metric)
+	units <- unique(sapply(metrics, function(m) metric_labels[[m]]$unit))
+	if (length(units) == 1){
+	    flag_strs <- make_flag_strs(driving_flag, metrics, metric_labels)
+	}else{ #non-unique units
+		warning(paste0(data_str, ' mixes units (', paste(metrics, collapse = ', '), ')'))
+		flag_strs <- NULL
+	}
+	return(flag_strs)
+}
+
+resolve_combined_flag_strs <- function(metric_values, data_str, driving_flag, metric_labels = METRIC_LABELS){
+	resolve_flag_strs(data.table(metric = metric_values), data_str, driving_flag, metric_labels)
 }
 
 #helper function to combine ede data from different config folders
@@ -417,13 +426,7 @@ ede_with_pop<- function(config_df_list){
 
 #makes a plot showing how y_EDEs change for each demographic group as the
 #number of polls is increased
-plot_poll_edes<-function(ede_df, driving_flag = DRIVING_FLAG){
-	#TODO: if (is.null(metric)) return(invisible(NULL)) 
-	#appears with every get_uniform_metric call. 
-	#can these be combined?
-	metric <- get_uniform_metric(ede_df, 'plot_poll_edes')
-	if (is.null(metric)) return(invisible(NULL))
-	flag_strs <- make_flag_strs(driving_flag, metric)
+plot_poll_edes<-function(ede_df, flag_strs){
 
 	title_str = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' to poll by demographic')
 	y_str = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' (', flag_strs$unit, ')')
@@ -443,10 +446,7 @@ plot_poll_edes<-function(ede_df, driving_flag = DRIVING_FLAG){
 
 #like plot_poll_edes, but plots just the y_edes for the
 # population as a whole, and not demographic groups
-plot_population_edes <- function(ede_df, driving_flag = DRIVING_FLAG){
-	metric <- get_uniform_metric(ede_df, 'plot_population_edes')
-	if (is.null(metric)) return(invisible(NULL))
-	flag_strs <- make_flag_strs(driving_flag, metric)
+plot_population_edes <- function(ede_df, flag_strs){
 
 	title_str = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' to poll')
 	y_str = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' (', flag_strs$unit, ')')
@@ -464,14 +464,8 @@ plot_population_edes <- function(ede_df, driving_flag = DRIVING_FLAG){
 
 #makes a plot showing how the y_EDEs for multiple config_sets change 
 #as the number of polls is increased, for a specified demographic_group 
-plot_multiple_edes<-function(ede_list, demo_grp, driving_flag = DRIVING_FLAG){
+plot_multiple_edes<-function(ede_list, demo_grp, flag_strs){
 	ede_df <- do.call(rbind, ede_list)
-	
-	metric <- get_uniform_metric(ede_df, 'plot_multiple_edes')	
-	if (is.null(metric)) return(invisible(NULL))
-
-	flag_strs <- make_flag_strs(driving_flag, metric)
-
 
 	title_str = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' to poll by demographic')
 	y_str = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' (', flag_strs$unit, ')')
@@ -493,7 +487,7 @@ plot_multiple_edes<-function(ede_list, demo_grp, driving_flag = DRIVING_FLAG){
 
 #makes two plots, one showing the y_ede the other avg distance
 #showing how these variables change across the included runs
-plot_historic_edes <- function(orig_ede, suffix = '', driving_flag = DRIVING_FLAG){
+plot_historic_edes <- function(orig_ede, flag_strs, suffix = ''){
 
 	#set x axis label order
 	descriptor_order <- unique(orig_ede$descriptor)
@@ -507,10 +501,6 @@ plot_historic_edes <- function(orig_ede, suffix = '', driving_flag = DRIVING_FLA
 	#does data contain scaling data
 	scale_bool = 'pct_demo_population' %in% names(orig_ede)
 	
-	metric <- get_uniform_metric(orig_ede, 'plot_historic_edes')
-	if (is.null(metric)) return(invisible(NULL))
-	flag_strs <- make_flag_strs(driving_flag, metric)
-
 	#labels for various types of data
 	y_EDE_label = paste0('Equity weighted', flag_strs$driving_str, flag_strs$word, ' (', flag_strs$unit, ')')
 	y_avg_label = paste0('Average', flag_strs$driving_str, flag_strs$word, ' (', flag_strs$unit, ')')
@@ -559,14 +549,14 @@ plot_historic_edes <- function(orig_ede, suffix = '', driving_flag = DRIVING_FLA
 
 #compares optimized runs with historical runs having the same number of
 #polls (via plot_historical_edes)
-plot_original_optimized <- function(config_ede, orig_ede, suffix = '', driving_flag = DRIVING_FLAG){
+plot_original_optimized <- function(config_ede, orig_ede, flag_strs, suffix = ''){
 	#select the relevant optimized runs
 	orig_num_polls <- unique(orig_ede$num_polls)
 	config_num_polls <- unique(config_ede$num_polls)
 	optimization_num_polls<- max(intersect(orig_num_polls, config_num_polls))
 	optimized_run_dfs <- config_ede[num_polls == optimization_num_polls]
 	orig_and_optimal <- rbind(orig_ede, optimized_run_dfs)
-	plot_historic_edes(orig_and_optimal, paste0('and_optimal', suffix), driving_flag)
+	plot_historic_edes(orig_and_optimal, flag_strs, paste0('and_optimal', suffix))
 
 }
 
@@ -597,11 +587,7 @@ plot_precinct_persistence <- function(precinct_df){
 }
 
 #make boxplots of the average distances traveled and the y_edes at each run
-plot_boxplots <- function(residence_df, driving_flag = DRIVING_FLAG){
-	metric <- get_uniform_metric(residence_df, 'plot_boxplots')
-	if (is.null(metric)) return(invisible(NULL))
-	flag_strs <- make_flag_strs(driving_flag, metric)
-
+plot_boxplots <- function(residence_df, flag_strs){
 	res_pop <- residence_df[demographic == 'population',
 		]
 	#avg distance
@@ -617,14 +603,10 @@ plot_boxplots <- function(residence_df, driving_flag = DRIVING_FLAG){
 }
 
 #make histogram of the average distances traveled in the historical and ideal situations
-plot_orig_ideal_hist <- function(orig_residence_df, config_residence_df, ideal_num, driving_flag = DRIVING_FLAG){
+plot_orig_ideal_hist <- function(orig_residence_df, config_residence_df, ideal_num, flag_strs){
 	orig_residence_df <- orig_residence_df[demographic == 'population', ]
 	ideal_residence_df <- config_residence_df[demographic == 'population', ][num_polls == ideal_num, ]
 	res_pop_orig_and_ideal <- rbind( ideal_residence_df, orig_residence_df)
-
-	metric <- get_uniform_metric(res_pop_orig_and_ideal, 'plot_orig_ideal_hist')
-	if (is.null(metric)) return(invisible(NULL))
-	flag_strs <- make_flag_strs(driving_flag, metric)
 
 	#avg_distance
 	title_str = paste0('Distribution of ', flag_strs$word, 's traveled by people by year and optimization')
@@ -654,7 +636,7 @@ plot_demographic_hist<- function(df, demo, flag_strs){
 	return(hist)
 }
 
-plot_original_optimized_demographic_hists <- function(config_residence_df, orig_residence_df, demographic_list = DEMOGRAPHIC_LIST, driving_flag = DRIVING_FLAG){
+plot_original_optimized_demographic_hists <- function(config_residence_df, orig_residence_df, demographic_list = DEMOGRAPHIC_LIST, flag_strs){
 
 	#select the relevant optimized runs
 	orig_num_polls <- unique(orig_residence_df$num_polls)
@@ -662,11 +644,6 @@ plot_original_optimized_demographic_hists <- function(config_residence_df, orig_
 	optimization_num_polls<- max(intersect(orig_num_polls, config_num_polls))
 	optimized_run_dfs <- config_residence_df[num_polls == optimization_num_polls]
 	orig_and_optimal <- rbind(orig_residence_df, optimized_run_dfs)
-	descriptor_list <- unique(orig_and_optimal$descriptor)
-
-	metric <- get_uniform_metric(orig_and_optimal, 'plot_original_optimized_demographic_hists')
-	if (is.null(metric)) return(invisible(NULL))
-	flag_strs <- make_flag_strs(driving_flag, metric)
 
 	demographic_hists = lapply(demographic_list, function(x)plot_demographic_hist(orig_and_optimal, x, flag_strs))
 }

--- a/R/result_analysis/utility_functions/graph_functions.R
+++ b/R/result_analysis/utility_functions/graph_functions.R
@@ -375,7 +375,7 @@ resolve_flag_strs <- function(df, data_str, driving_flag, metric_labels = METRIC
 	metrics <- unique(df$metric)
 	units <- unique(sapply(metrics, function(m) metric_labels[[m]]$unit))
 	if (length(units) == 1){
-	    flag_strs <- make_flag_strs(driving_flag, metrics, metric_labels)
+	    flag_strs <- make_flag_strs(driving_flag, metrics[1], metric_labels)
 	}else{ #non-unique units
 		warning(paste0(data_str, ' mixes units (', paste(metrics, collapse = ', '), ')'))
 		flag_strs <- NULL

--- a/R/result_analysis/utility_functions/graph_functions.R
+++ b/R/result_analysis/utility_functions/graph_functions.R
@@ -87,11 +87,13 @@ select_varying_fields <- function(config_dt){
 	return(result_dt)
 }
 
-#TODO: this needs documentation
+#scale all distance-bearing columns in a result output by the metric's unit 
 scale_distance_columns <- function(dt, metric_labels = METRIC_LABELS){
-	#scale distance-bearing columns by the metric's unit 
+	#rename columns
 	scale_lookup <- setNames(metric_labels$scale, metric_labels$metric)
+	#identify distance columns
 	distance_cols <- intersect(c('distance_m', 'weighted_dist', 'avg_dist', 'y_EDE'), names(dt))
+	#if they exist, scale them
 	if (length(distance_cols) > 0){
 		dt[ , (distance_cols) := lapply(.SD, function(x) x * scale_lookup[metric]), .SDcols = distance_cols]
 	}
@@ -233,7 +235,6 @@ load_results_from_csv <-function(config_dt, result_type){
 	#read data, add config_set and config_name columns
 	#note, this needs a local function
 	dt_list <- lapply(file_path, fread)
-	names(dt_list) <- names(file_path)
 	dt_list_appended <- mapply(function(data, list_name){data[, config_name:=list_name][ , config_set := config_folder][ , location := location]}, dt_list, names(dt_list), SIMPLIFY = FALSE)
 	
 	#combine into one df
@@ -304,9 +305,6 @@ assign_descriptor_to_result<- function(config_dt, result_type, field_of_interest
 	#order the descriptor fields as factors
 	complete_dt <- order_descriptors(complete_dt)
 
-	#TODO: I don't like this here
-	complete_dt <- scale_distance_columns(complete_dt)
-
 	#fix data types (only needed for csv)
 	if ('id_dest' %in% names(complete_dt)){
 		complete_dt[ , id_dest:= as.character(id_dest)]}
@@ -337,6 +335,8 @@ read_result_data<- function(config_dt, field_of_interest = '', descriptor_dict =
 	num_residences <- df_list$residence_distances[ , .(num_residences = .N/6), by = descriptor]
 	nums_to_join <- merge(num_polls, num_residences, all = T)
 	appended_df_list <- lapply(df_list, function(df){merge(df, nums_to_join, by = 'descriptor', all.x = T)})
+	#scale the distance if necessary
+	appended_df_list <- lapply(appended_df_list, scale_distance_columns)
 
 	# Track information about configs used in this analsysis
 	mapply(add_config_info_to_graph_file_manifest, config_dt$id, config_dt$config_set, config_dt$config_name)

--- a/R/result_analysis/utility_functions/graph_functions.R
+++ b/R/result_analysis/utility_functions/graph_functions.R
@@ -15,11 +15,11 @@ TABLES = c("edes", "precinct_distances", "residence_distances", "results")
 DEMO_COLS =  c("population", "hispanic","non_hispanic", "white", "black", "native", "asian", "pacific_islander", "other")
 
 PRINT_SQL = FALSE
-METRIC_LABELS <- list(
-	haversine        = list(word = 'distance', unit = 'm',   scale = 1),
-	driving_distance = list(word = 'distance', unit = 'm',   scale = 1),
-	driving_time     = list(word = 'time',     unit = 'min', scale = 1 / 60)
-)
+METRIC_LABELS <- data.table(
+						metric = c('haversine', 'driving_distance', 'driving_time'),
+						word = c('distance', 'distance', 'time'),
+						unit = c('m', 'm', 'min'),
+						scale = c(1, 1, 1/60))
 
 #########
 #Get flags from the config folders or config file
@@ -87,9 +87,10 @@ select_varying_fields <- function(config_dt){
 	return(result_dt)
 }
 
+#TODO: this needs documentation
 scale_distance_columns <- function(dt, metric_labels = METRIC_LABELS){
 	#scale distance-bearing columns by the metric's unit 
-	scale_lookup <- sapply(metric_labels, function(x) x$scale)
+	scale_lookup <- setNames(metric_labels$scale, metric_labels$metric)
 	distance_cols <- intersect(c('distance_m', 'weighted_dist', 'avg_dist', 'y_EDE'), names(dt))
 	if (length(distance_cols) > 0){
 		dt[ , (distance_cols) := lapply(.SD, function(x) x * scale_lookup[metric]), .SDcols = distance_cols]
@@ -359,12 +360,15 @@ demographic_legend_dict <- c(
 	'population' = 'Total')
 
 #helper function to make graph titles according to flag values and metric units
-make_flag_strs <- function(driving_flag, metric, metric_labels = METRIC_LABELS){
+make_flag_strs <- function(driving_flag, available_metrics, metric_labels = METRIC_LABELS){
 	#make flag/metric dependent labels
 	driving_str <- ' straight line '
 	if (driving_flag){driving_str <- ' driving '}
-	metric_info <- METRIC_LABELS[[metric]]
-	return(as.list(c(driving_str = driving_str, word = metric_info$word, unit = metric_info$unit)))
+	metric_info <- metric_labels[metric %in% available_metrics, ]
+	if(length(unique(metric_info$word))>1){
+		stop(paste(paste(available_metrics, collapse = ','), ' has multiple associated words'))
+	}
+ 	return(as.list(c(driving_str = driving_str, word = unique(metric_info$word), unit = unique(metric_info$unit))))
 }
 
 #helper to guard plot functions against mixed-metric input data.
@@ -373,9 +377,9 @@ resolve_flag_strs <- function(df, data_str, driving_flag, metric_labels = METRIC
 	
 	#first, get check if the data mixes units. 
 	metrics <- unique(df$metric)
-	units <- unique(sapply(metrics, function(m) metric_labels[[m]]$unit))
+	units <- unique(metric_labels[.(metrics), on = 'metric', unit])
 	if (length(units) == 1){
-	    flag_strs <- make_flag_strs(driving_flag, metrics[1], metric_labels)
+	    flag_strs <- make_flag_strs(driving_flag, metrics, metric_labels)
 	}else{ #non-unique units
 		warning(paste0(data_str, ' mixes units (', paste(metrics, collapse = ', '), ')'))
 		flag_strs <- NULL
@@ -666,11 +670,11 @@ plot_population_densities <- function(density_df){
 #plot of average distances traveled by demographic groups, aggregated 
 #at the block group level, ordered by population density
 #log / log scale, with best fit lines
-plot_density_v_distance_bg <- function(bg_density_data, county, demo_list, driving_flag = DRIVING_FLAG){
+plot_density_v_distance_bg <- function(bg_density_data, county, demo_list, driving_flag = DRIVING_FLAG, metric_labels = METRIC_LABELS){
 	#trim log density outliers
 	trimmed <- bg_density_data[abs(z_score_log_density)<4, ]
 	#tag each row with its metric's unit, so bounds can be computed per unit below
-	trimmed[, unit := sapply(metric, function(m) METRIC_LABELS[[m]]$unit)]
+	trimmed[metric_labels, unit := i.unit, on = 'metric']
 
     descriptor_graph <- function(descriptor_str, demo_list, y_bounds, metric){
 		flag_strs <- make_flag_strs(driving_flag, metric)

--- a/R/result_analysis/utility_functions/map_functions.R
+++ b/R/result_analysis/utility_functions/map_functions.R
@@ -248,7 +248,7 @@ distance_bounds <- function(df){
 
 	# pull out global bounds
 	global_max <- max(bound_dt$max_avg_dist)
-	global_min <- max(bound_dt$min_avg_dist)
+	global_min <- min(bound_dt$min_avg_dist)
 	color_bounds <- list(global_min, global_max)
 	return(color_bounds)
 }

--- a/R/result_analysis/utility_functions/map_functions.R
+++ b/R/result_analysis/utility_functions/map_functions.R
@@ -240,7 +240,7 @@ distance_bounds <- function(df, metric_labels = METRIC_LABELS){
 
 	prepped_df <- copy(df)
 	#get a column of units
-	prepped_df[, unit := sapply(metric, function(m) metric_labels[[m]]$unit)]
+	prepped_df[metric_labels, unit := i.unit, on = 'metric']
 
 	# pull out min and max average distances by location
 	bound_dt <- prepped_df[, .(min_avg_dist = min(avg_dist), max_avg_dist = max(avg_dist)), 

--- a/R/result_analysis/utility_functions/map_functions.R
+++ b/R/result_analysis/utility_functions/map_functions.R
@@ -99,7 +99,7 @@ results_with_area_geom<- function(location, result_df){
 demographically_weighted_distances <- function(result_df){
 	#takes a result df and calculates the weighted distance for each demographic group
 	#in block
-	weighted_df <- result_df[,lapply(.SD, function(x)distance_m*x), by = c('id_orig', 'config_name', 'config_set', 'descriptor'), .SDcols = DEMO_COLS]
+	weighted_df <- result_df[,lapply(.SD, function(x)distance_m*x), by = c('id_orig', 'config_name', 'config_set', 'descriptor', 'metric'), .SDcols = DEMO_COLS]
 
 	return(weighted_df)
 }
@@ -121,16 +121,16 @@ bg_result_geom <- function(location, result_df){
 	bg_weighted_dist <- block_weighted_dist[ , bg_id := gsub('.{3}$', '', id_orig)]
 
 	#aggregate demographics to block group level
-	bg_demo <- bg_result_geom[ , lapply(.SD, sum), by = c('bg_id','config_set', 'config_name', 'descriptor'), .SDcols = DEMO_COLS]
-	bg_weight <- bg_weighted_dist[ , lapply(.SD, sum), by = c('bg_id','config_set', 'config_name', 'descriptor'), .SDcols = DEMO_COLS]
+	bg_demo <- bg_result_geom[ , lapply(.SD, sum), by = c('bg_id','config_set', 'config_name', 'descriptor', 'metric'), .SDcols = DEMO_COLS]
+	bg_weight <- bg_weighted_dist[ , lapply(.SD, sum), by = c('bg_id','config_set', 'config_name', 'descriptor', 'metric'), .SDcols = DEMO_COLS]
 
 	#melt both
-	id_cols = c('bg_id','config_set', 'config_name', 'descriptor')
+	id_cols = c('bg_id','config_set', 'config_name', 'descriptor', 'metric')
 	demo_data_long <- melt(bg_demo, id.vars = id_cols, measure.vars = DEMO_COLS, value.name ='demo_pop' , variable.name = "demographic")
 	weight_data_long <- melt(bg_weight, id.vars = id_cols, measure.vars = DEMO_COLS, value.name ='demo_weighted_dist' , variable.name = "demographic")
 
 	#merge the two datasets to get one with both demo_pop and demo_weighted_distance columns
-	bg_demo_weight <- merge(demo_data_long, weight_data_long, by = c('bg_id','config_set', 'config_name', 'descriptor', 'demographic'))
+	bg_demo_weight <- merge(demo_data_long, weight_data_long, by = c('bg_id','config_set', 'config_name', 'descriptor', 'demographic', 'metric'))
 
 	#create a demographic average distance column
 	bg_demo_weight <- bg_demo_weight[ , demo_avg_dist := demo_weighted_dist/demo_pop]
@@ -235,21 +235,24 @@ prepare_outputs_for_precinct_maps <- function(result_dt){
 #Calculate min and max distance for a dataframe
 ###########
 
-distance_bounds <- function(df){
+distance_bounds <- function(df, metric_labels = METRIC_LABELS){
 	#calculate the min and max average distances traveled by census block for maps by location
 
 	prepped_df <- copy(df)
+	#get a column of units
+	prepped_df[, unit := sapply(metric, function(m) metric_labels[[m]]$unit)]
+
 	# pull out min and max average distances by location
-	bound_dt <- prepped_df[, .(min_avg_dist = min(avg_dist), max_avg_dist = max(avg_dist)), by = location]
+	bound_dt <- prepped_df[, .(min_avg_dist = min(avg_dist), max_avg_dist = max(avg_dist)), 
+						by = c('location', 'unit')]
 
 	# check for missing data
 	if (any(sapply(bound_dt, anyNA))){
     warning('Some location does not have a min or max average distance for mapping')}
 
+	
 	# pull out global bounds
-	global_max <- max(bound_dt$max_avg_dist)
-	global_min <- min(bound_dt$min_avg_dist)
-	color_bounds <- list(global_min, global_max)
+	color_bounds <- bound_dt[, .(global_max = max(max_avg_dist), global_min = min(min_avg_dist)), by = unit]
 	return(color_bounds)
 }
 
@@ -258,7 +261,9 @@ distance_bounds <- function(df){
 #Make block group maps
 ###############
 
-make_bg_maps <-function(prepped_data, demo_str = 'population', driving_flag = DRIVING_FLAG, log_flag = LOG_FLAG, color_bounds = global_color_bounds, linear_color_gradient = LINEAR_COLOR_GRADIENT){ 
+make_bg_maps <-function(prepped_data, demo_str = 'population', driving_flag = DRIVING_FLAG,
+						 color_bounds = global_color_bounds,
+						 linear_color_gradient = LINEAR_COLOR_GRADIENT){ 
 	#use aggregated result data to color the map by distance to matched location, for population at large
 	#and plots the polling locations
 	
@@ -267,25 +272,28 @@ make_bg_maps <-function(prepped_data, demo_str = 'population', driving_flag = DR
 	bg_demo_sf <- st_as_sf(prepped_demo)
 
 	#make maps labels based on flags
-	flag_strs <- make_flag_strs(driving_flag, log_flag)
+	metric <- unique(prepped_data$metric)
+	flag_strs <- make_flag_strs(driving_flag, metric)
 	
-	title_str = paste0('Average', flag_strs$driving_str, 'distance to poll (', flag_strs$log_str, 'm)')
-	fill_str = paste0('Avg distance (', flag_strs$log_str, 'm)')
+	title_str = paste0('Average', flag_strs$driving_str, flag_strs$word, ' to poll (', flag_strs$unit, ')')
+	fill_str = paste0('Avg ', flag_strs$word, ' (', flag_strs$unit, ')')
 
 	county = gsub('.{3}$','', unique(prepped_data$location))
 	descriptor = paste(county, unique(prepped_data$descriptor), sep ='_')
 	
 	#make maps
+	#select bounds
+	color_bounds <- color_bounds[unit == flag_strs$unit, ]
 	#color by bg avg distance
 	if(linear_color_gradient){
 		plotted <- ggplot() +
 			geom_sf(data = bg_demo_sf, aes(fill = demo_avg_dist)) +
-			scale_fill_map_distance(limits = c(color_bounds[[1]], color_bounds[[2]]), name = fill_str)
+			scale_fill_map_distance(limits = c(color_bounds$global_min, color_bounds$global_max), name = fill_str)
 	} else{
-		break_vector = round(c(color_bounds[[1]], color_bounds[[1]] + (color_bounds[[2]]-color_bounds[[1]])/4, color_bounds[[1]] + (color_bounds[[2]]-color_bounds[[1]])/2, color_bounds[[1]] + 3*(color_bounds[[2]]-color_bounds[[1]])/4), digits = -2)
+		break_vector = signif(c(color_bounds$global_min, color_bounds$global_min + (color_bounds$global_max-color_bounds$global_min)/4, color_bounds$global_min + (color_bounds$global_max-color_bounds$global_min)/2, color_bounds$global_min + 3*(color_bounds$global_max-color_bounds$global_min)/4), digits = 2)
 		plotted <- ggplot() +
 			geom_sf(data = bg_demo_sf, aes(fill = demo_avg_dist)) +
-			scale_fill_map_distance(limits = c(color_bounds[[1]], color_bounds[[2]]), name = fill_str, transform = 'log', breaks = break_vector)
+			scale_fill_map_distance(limits = c(color_bounds$global_min, color_bounds$global_max), name = fill_str, transform = 'log', breaks = break_vector)
 	}
 
 	#place polling locations
@@ -302,7 +310,7 @@ make_bg_maps <-function(prepped_data, demo_str = 'population', driving_flag = DR
 	ggsave(graph_file_path, plotted)
 }
 
-make_demo_dist_map <-function(prepped_data, demo_str, driving_flag = DRIVING_FLAG, log_flag = LOG_FLAG, color_bounds = global_color_bounds, linear_color_gradient = LINEAR_COLOR_GRADIENT){
+make_demo_dist_map <-function(prepped_data, demo_str, driving_flag = DRIVING_FLAG, color_bounds = global_color_bounds, linear_color_gradient = LINEAR_COLOR_GRADIENT){
 	#use demographic residence_distances to put a dot in  the map colored by distance and sized by population
 	
 	#transform for prepped data for mapping
@@ -317,10 +325,11 @@ make_demo_dist_map <-function(prepped_data, demo_str, driving_flag = DRIVING_FLA
 	
 	#plot map with a point at the centroid, colored by distance, sized by size
 	#set names
-	flag_strs <- make_flag_strs(driving_flag, log_flag)
+	metric <- unique(prepped_data$metric)
+	flag_strs <- make_flag_strs(driving_flag, metric)
 
-	title_str = paste0('Average', flag_strs$driving_str, 'distance to poll (', flag_strs$log_str, 'm)')
-	color_str = paste0('Avg distance (', flag_strs$log_str, 'm)')
+	title_str = paste0('Average', flag_strs$driving_str, flag_strs$word, ' to poll (', flag_strs$unit, ')')
+	color_str = paste0('Avg ', flag_strs$word, ' (', flag_strs$unit, ')')
 
 	county = gsub('.{3}$','', unique(prepped_data$location))
 	descriptor = paste(county, unique(prepped_data$descriptor), sep ='_')
@@ -329,21 +338,23 @@ make_demo_dist_map <-function(prepped_data, demo_str, driving_flag = DRIVING_FLA
 	#for ease of comparison across demographics)
 	max_pop <- max(prepped_data$demo_pop)
 
+	color_bounds <- color_bounds[unit == flag_strs$unit, ]
+
 	if(linear_color_gradient){
 		plotted <- ggplot() +
 			geom_sf(data = bg_demo_sf) +
 			geom_point(data = bg_demo_sf, aes(x = INTPTLON20, y = INTPTLAT20, size= demo_pop, color = demo_avg_dist)) +
-			scale_color_map_distance(limits = c(color_bounds[[1]], color_bounds[[2]]), name = color_str) +
+			scale_color_map_distance(limits = c(color_bounds$global_min, color_bounds$global_max), name = color_str) +
 			labs(size = paste(demographic_legend_dict[demo_str], 'population') ) +
 			xlab('') + ylab('') + scale_size(limits= c(0, max_pop)) +
 			ggtitle(paste(demographic_legend_dict[demo_str], title_str), paste('Block groups in', gsub('_', ' ', descriptor))) +
 			theme_tableau_map()
 		} else{
-			break_vector = round(c(color_bounds[[1]], color_bounds[[1]] + (color_bounds[[2]]-color_bounds[[1]])/4, color_bounds[[1]] + (color_bounds[[2]]-color_bounds[[1]])/2, color_bounds[[1]] + 3*(color_bounds[[2]]-color_bounds[[1]])/4), digits = -2)
+			break_vector = signif(c(color_bounds$global_min, color_bounds$global_min + (color_bounds$global_max-color_bounds$global_min)/4, color_bounds$global_min + (color_bounds$global_max-color_bounds$global_min)/2, color_bounds$global_min + 3*(color_bounds$global_max-color_bounds$global_min)/4), digits = 2)
 			plotted <- ggplot() +
 				geom_sf(data = bg_demo_sf) +
 				geom_point(data = bg_demo_sf, aes(x = INTPTLON20, y = INTPTLAT20, size= demo_pop, color = demo_avg_dist)) +
-				scale_color_map_distance(limits = c(color_bounds[[1]], color_bounds[[2]]), name = color_str, transform = 'log', breaks = break_vector) +
+				scale_color_map_distance(limits = c(color_bounds$global_min, color_bounds$global_max), name = color_str, transform = 'log', breaks = break_vector) +
 				labs(size = paste(demographic_legend_dict[demo_str], 'population') ) +
 				xlab('') + ylab('') + scale_size(limits= c(0, max_pop)) +
 				ggtitle(paste(demographic_legend_dict[demo_str], title_str), paste('Block groups in', gsub('_', ' ', descriptor))) +

--- a/R/result_analysis/utility_functions/regression_functions.r
+++ b/R/result_analysis/utility_functions/regression_functions.r
@@ -4,6 +4,7 @@ library(stringr)
 library(here)
 
 source('R/result_analysis/utility_functions/load_config_data.R')
+source('R/result_analysis/utility_functions/graph_functions.R')
 source('R/result_analysis/utility_functions/map_functions.R')
 source('R/result_analysis/utility_functions/storage.R')
 
@@ -80,7 +81,7 @@ bg_level_naive_regression <- function(regression_data){
 	trimmed <- regression_data[abs(z_score_log_density)<4, ]
 	distance_model <- trimmed[, as.list(coef(lm(log(demo_avg_dist) ~ log(pop_density_km)),  weights = demo_pop )), by = c('descriptor', 'demographic')]
     setnames(distance_model, c('(Intercept)', 'log(pop_density_km)'), c('intercept', 'density_coef'))
-	csv_file_path = paste(config_set, '_distance_model.csv', sep= '_')
+	csv_file_path = paste(config_set, 'distance_model.csv', sep= '_')
 	add_graph_to_graph_file_manifest(csv_file_path)
 	fwrite(distance_model, csv_file_path)
 	return(distance_model)


### PR DESCRIPTION
## Summary
- Make `R/result_analysis/utility_functions/graph_functions.R` and `map_functions.R` metric-aware: a `driving_time`-optimized run now renders with time-based labels/units (minutes) instead of being mislabeled as distance in meters.
- `metric` is propagated as a per-row data column (via `select_varying_fields`/`create_descriptor_field`/`assign_descriptor_to_result`), with distance-bearing columns (`distance_m`/`weighted_dist`/`avg_dist`/`y_EDE`) scaled once at load time.
- Plot functions that combine descriptors on one shared axis warn-and-skip when the input mixes incompatible units (meters vs. minutes) rather than mislabeling or erroring; `haversine`/`driving_distance` (both meters) are treated as compatible.
- Map color scales (`distance_bounds()`) and the density-vs-distance regression plot (`plot_density_v_distance_bg`) compute bounds per unit instead of skipping, so mixed-metric config folders still render apples-to-apples comparisons within each metric.
- Dropped dead `log_flag`/`log_str` handling (a no-op since the code path that set it was commented out).

##Review note

Author has concerns about code quality. Feedback on how to refactor and improve data flow would be greatly appreciated.

## Test plan
- [x] Ran `R/result_analysis/Basic_analysis.r` end-to-end against `Monongalia_County_WV_driving_original_configs` (mixes `driving_distance` and `driving_time` configs in one folder) — completes with no errors.
- [x] Confirmed correct word/unit ("distance (m)" vs "time (min)") on generated plots and maps for each metric.
- [x] Confirmed mixed-metric plots warn and skip instead of erroring or mislabeling.
- [ ] `python run.py test` / `pylint python/` (no Python changes in this PR, but included per repo convention)