### PR TITLE
fix(utils): reject negative driving distances/durations at generation (#294)

### DIFF
--- a/python/solver/model_data.py
+++ b/python/solver/model_data.py
@@ -321,9 +321,10 @@ class BuildDistanceMetaData:
 # log, purely to avoid log(0) = -inf. Per-metric because a meter and a second are
 # different units; a coincident pair (a block centroid on its own site) is
 # essentially zero travel, so these keep the log finite and strongly negative.
-# Non-negativity of the RAW values is guaranteed upstream, when the driving matrix
-# is built (_coerce_negative_metrics_to_null in driving_distance_matrix), so this
-# floor only handles legitimate exactly-zero (coincident) pairs.
+# Non-negativity of the RAW values is enforced upstream: building the driving
+# matrix rejects any negative distance/duration (_reject_negative_metric_values in
+# driving_distance_matrix), so this floor only handles legitimate exactly-zero
+# (coincident) pairs.
 LOG_ZERO_DISTANCE_FLOOR_M = 0.001
 LOG_ZERO_DURATION_FLOOR_S = 0.5
 

--- a/python/tests/driving_distance_matrix_test.py
+++ b/python/tests/driving_distance_matrix_test.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from python.utils.driving_distance_matrix import (
     MATRIX_CELL_LIMIT,
@@ -11,8 +12,8 @@ from python.utils.driving_distance_matrix import (
     _LEVEL_DEFAULT,
     _LEVEL_V,
     _LEVEL_VV,
-    _coerce_negative_metrics_to_null,
     _emit,
+    _reject_negative_metric_values,
     build_distance_matrix,
     estimate_origin,
     get_missing_origins,
@@ -348,46 +349,61 @@ class TestVerbosityGating:
         assert 'no neighbor within 1km, dropped' in capsys.readouterr().out
 
 
-class TestCoerceNegativeMetricsToNull:
-    '''Negative distance_m OR duration_s is mapped to NaN; 0 and positives kept.'''
+class TestRejectNegativeMetricValues:
+    '''A negative distance_m OR duration_s is invalid and raises; 0/positive/null pass.'''
 
-    def test_negative_distance_and_duration_become_nan(self):
+    def test_negative_distance_raises(self):
+        df = pd.DataFrame({
+            'id_orig': ['a', 'b'],
+            'id_dest': ['x', 'x'],
+            'distance_m': [-1.0, 50.0],
+            'duration_s': [12.0, 30.0],
+        })
+        with pytest.raises(ValueError, match='negative'):
+            _reject_negative_metric_values(df)
+
+    def test_negative_duration_raises(self):
+        df = pd.DataFrame({
+            'id_orig': ['a', 'b'],
+            'id_dest': ['x', 'x'],
+            'distance_m': [10.0, 50.0],
+            'duration_s': [-2.0, 30.0],
+        })
+        with pytest.raises(ValueError, match='negative'):
+            _reject_negative_metric_values(df)
+
+    def test_zero_positive_and_null_values_pass(self):
+        # 0 (a residence at its own polling place) and ORS nulls (no-route, NaN)
+        # are valid, not negative, so the check must not raise.
         df = pd.DataFrame({
             'id_orig': ['a', 'b', 'c'],
             'id_dest': ['x', 'x', 'x'],
-            'distance_m': [-1.0, 0.0, 50.0],
-            'duration_s': [12.0, -2.0, 30.0],
+            'distance_m': [0.0, 50.0, float('nan')],
+            'duration_s': [0.0, 30.0, float('nan')],
         })
-        result = _coerce_negative_metrics_to_null(df)
-        assert pd.isnull(result.loc[0, 'distance_m'])   # -1 distance -> NaN
-        assert result.loc[1, 'distance_m'] == 0.0       # 0 kept
-        assert result.loc[2, 'distance_m'] == 50.0      # positive kept
-        assert result.loc[0, 'duration_s'] == 12.0      # positive kept
-        assert pd.isnull(result.loc[1, 'duration_s'])   # -2 duration -> NaN
-        assert result.loc[2, 'duration_s'] == 30.0      # positive kept
+        _reject_negative_metric_values(df)
 
 
 class TestBuildMatrixNegativeHandling:
-    '''A negative matrix cell is treated as unroutable, never emitted.'''
+    '''A negative matrix cell is invalid and aborts the build with a ValueError.'''
 
     @patch('python.utils.driving_distance_matrix.query_matrix')
-    def test_negative_distance_treated_as_unroutable_and_snapped(self, mock_query):
-        # s1's cell is negative -> must be coerced to NaN and snapped to s0.
+    def test_negative_distance_raises(self, mock_query):
+        # s1's cell is negative -> invalid data, must abort the build (not snap).
         mock_query.return_value = {'distance': [[100.0], [-1.0]], 'duration': [[12.0], [24.0]]}
         log_fh = io.StringIO()
-        df = build_distance_matrix(
-            locations={
-                's0': [-84.0000, 33.9500],
-                's1': [-84.0000, 33.9510],  # ~111m north of s0, within 1km
-                'd':  [-84.1000, 34.0000],
-            },
-            source_ids=['s0', 's1'],
-            dest_ids=['d'],
-            matrix_url='http://ors:8082/ors/v2/matrix/driving-car',
-            log_fh=log_fh, verbosity=0,
-        )
-        assert (df['distance_m'] >= 0).all()
-        assert 'snapped to nearest haversine neighbor' in log_fh.getvalue()
+        with pytest.raises(ValueError, match='negative'):
+            build_distance_matrix(
+                locations={
+                    's0': [-84.0000, 33.9500],
+                    's1': [-84.0000, 33.9510],
+                    'd':  [-84.1000, 34.0000],
+                },
+                source_ids=['s0', 's1'],
+                dest_ids=['d'],
+                matrix_url='http://ors:8082/ors/v2/matrix/driving-car',
+                log_fh=log_fh, verbosity=0,
+            )
 
 
 class TestMatrixResponseCarriesDuration:

--- a/python/utils/driving_distance_matrix.py
+++ b/python/utils/driving_distance_matrix.py
@@ -95,23 +95,34 @@ def matrix_response_to_long_df(source_names, dest_names, distances, durations) -
     )
 
 
-def _coerce_negative_metrics_to_null(df: pd.DataFrame) -> pd.DataFrame:
-    '''Replace any negative ``distance_m`` or ``duration_s`` with NaN, in place.
+def _reject_negative_metric_values(df: pd.DataFrame) -> None:
+    '''Raise if any ``distance_m`` or ``duration_s`` is negative.
 
-    ORS signals "no route" with null, which becomes NaN and is recovered by the
-    snap/retry path. A negative distance or duration is never a valid real-world
-    value; if a routing backend ever emits one, treat it as no-route so it flows
-    through the same recovery and never reaches the output CSV. ``0`` is kept.
+    A negative driving distance or duration is physically impossible, so it can
+    only signal a routing-backend error. Per the #294 decision, such a value is
+    treated as invalid and fails the run loudly here, at data generation, rather
+    than being silently recovered. A genuine "no route" arrives from ORS as null
+    (NaN), not a negative, and is left untouched for the snap/drop recovery
+    downstream; ``0`` is a valid distance (a residence at its own polling place)
+    and is also kept.
 
     Args:
         df: Long-form DataFrame with ``distance_m`` and ``duration_s`` columns.
 
-    Returns:
-        The same DataFrame, with any negative ``distance_m``/``duration_s`` set to NaN.
+    Raises:
+        ValueError: If any row has a negative ``distance_m`` or ``duration_s``.
     '''
-    df.loc[df[DISTANCE_DISTANCE_M] < 0, DISTANCE_DISTANCE_M] = float('nan')
-    df.loc[df[DISTANCE_DURATION_S] < 0, DISTANCE_DURATION_S] = float('nan')
-    return df
+    negative_mask = (df[DISTANCE_DISTANCE_M] < 0) | (df[DISTANCE_DURATION_S] < 0)
+    if negative_mask.any():
+        offender = df[negative_mask].iloc[0]
+        raise ValueError(
+            f'{int(negative_mask.sum())} routed pair(s) have a negative distance_m or '
+            f'duration_s, which is never a valid travel metric (first: '
+            f'{offender[DISTANCE_ID_ORIG]} -> {offender[DISTANCE_ID_DEST]}, '
+            f'distance_m={offender[DISTANCE_DISTANCE_M]}, '
+            f'duration_s={offender[DISTANCE_DURATION_S]}). A negative value signals a '
+            f'routing-backend error; regenerate the driving matrix.'
+        )
 
 
 def estimate_origin(origin: str, df: pd.DataFrame, locations: dict) -> pd.DataFrame:
@@ -399,9 +410,10 @@ def build_distance_matrix(*,
         )
         df = pd.concat([df, retry_df], ignore_index=True)
 
-    # Treat any negative distance or duration as no-route before snapping, so it
-    # flows through the same recovery as a real ORS null and never reaches the CSV.
-    df = _coerce_negative_metrics_to_null(df)
+    # A negative distance or duration is physically impossible; per #294, reject it
+    # as invalid and fail loudly rather than silently recovering it. Real ORS nulls
+    # (no-route) are untouched and still snap/drop below.
+    _reject_negative_metric_values(df)
 
     return _snap_unroutable_origins(
         df, source_ids, locations,


### PR DESCRIPTION
Implements the coerce-vs-raise decision from #294: a negative driving distance/duration is now **treated as invalid and fails loudly at data generation**, rather than being silently coerced to null and recovered.

## Background

`build_distance_matrix` previously ran `_coerce_negative_metrics_to_null`, which masked any negative `distance_m`/`duration_s` to NaN so it flowed through the same snap/drop recovery as a real ORS no-route. Per Susama's call on #294 ("go with true-as-invalid"), a negative value is physically impossible and should surface as an error, not be absorbed.

## Change

- Rename `_coerce_negative_metrics_to_null` → `_reject_negative_metric_values`. It now raises `ValueError` on any negative `distance_m`/`duration_s`, naming the first offending `(id_orig, id_dest)` pair and the count.
- A genuine ORS **no-route** arrives as **null (NaN)**, not a negative — untouched, still snaps/drops downstream.
- **0 stays valid** (a residence at its own polling place). Exact-zero is floored to the per-metric epsilon (0.001 m / 0.5 s) later, at the log transform — that's #295's behavior, unchanged here.
- Update the call site and the `model_data.py` floor comment that referenced the old function name.

## Scope boundary

This is the **generation-side** counterpart to #295/#296 (which validated *before* the log transform, on the solver side). Negatives only — zeros and nulls are deliberately left untouched, so legitimate same-block (zero-burden) voters are never rejected.

## Tests

- Rewrote the unit + integration tests to assert the raise: negative distance raises, negative duration raises, and 0/positive/null pass; a negative matrix cell aborts `build_distance_matrix`.
- `pytest -m "not e2e_db"`: **383 passed, 1 skipped**. `pylint` **10.00/10** on the changed files. (`e2e_db` needs live BigQuery credentials and is not exercised here.)

Implements the #294 decision (the KP-EDE comparison discussion tracked on #294 remains open). Base: `feature/driving-time-metric` (already includes #296).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
