### PR TITLE
fix(r-analysis): normalize blank strings to NA after every pipeline read

### DIFF
--- a/R/result_analysis/WV_state_file_corrections/Monongalia_reconciliation.r
+++ b/R/result_analysis/WV_state_file_corrections/Monongalia_reconciliation.r
@@ -64,7 +64,7 @@ setwd(precinct_analysis_output_folder)
 
 #read in correction data
 RECONCILIATION_CSV <- "location_precinct_mismatches.csv"
-reconciliation_data <- fread(RECONCILIATION_CSV)
+reconciliation_data <- safe_fread(RECONCILIATION_CSV)
 
 #build crosswalk
 crosswalk <- build_precinct_crosswalk(reconciliation_data)

--- a/R/result_analysis/scripts/extract_precincts.r
+++ b/R/result_analysis/scripts/extract_precincts.r
@@ -54,7 +54,7 @@ if (COUNTY_PROVIDES_PRECINCT_DATA) {
   #check if mismatches have been addressed
   mismatches_path <- file.path(precinct_analysis_output_folder, "location_precinct_mismatches.csv")
   if (file.exists(mismatches_path)) {
-    reconciliation_data <- fread(mismatches_path)
+    reconciliation_data <- safe_fread(mismatches_path)
     state_precincts <- apply_corrections(state_precincts, reconciliation_data)
   }
   #use this to reconcile state data
@@ -109,7 +109,7 @@ setwd(file.path(here(), precinct_analysis_output_folder))
 #map the state_provided precinct to the reolved polling locations
 crosswalk_path <- "precinct_polling_location_crosswalk.csv"
 state_county_crosswalk <- if (file.exists(crosswalk_path)) {
-  fread(crosswalk_path)
+  safe_fread(crosswalk_path)
 } else {
   # no correction script has ever run for this county -- every precinct's
   # as-provided USER_POLL_ is already correct, so an empty crosswalk (every
@@ -120,8 +120,8 @@ state_county_crosswalk <- if (file.exists(crosswalk_path)) {
 #read in block assignment: each block's dominant precinct (from
 #flag_state_provided_precincts.r's Step 3), with each block's full
 #geometry.
-block_precinct_assignment <- st_read(
-  file.path("block_precinct_assignment.gpkg"))
+block_precinct_assignment <- normalize_missing_strings(st_read(
+  file.path("block_precinct_assignment.gpkg")))
 names(block_precinct_assignment)[names(block_precinct_assignment) == "geometry"] <- "block_geometry"
 st_geometry(block_precinct_assignment) <- "block_geometry"
 

--- a/R/result_analysis/utility_functions/city_shape_functions.r
+++ b/R/result_analysis/utility_functions/city_shape_functions.r
@@ -15,6 +15,32 @@ TIGER_FOLDER <- "datasets/census/tiger"
 REDISTRICTING_FOLDER <- "datasets/census/redistricting"
 DEMO_BG_FOLDER <- "block group demographics"
 
+######## Missing-value normalization ########
+# fwrite()/st_write() write NA_character_ as a blank cell either way, but
+# fread() only recognizes literal "NA" text on the way back in, and st_read()
+# has no na-string option at all -- DBF doesn't have a real NULL to give it.
+# Without this, we have to is.na(x) | x == ''. Collapse "" back to NA right 
+# after each read. instead, this lets us just use is.na downstream without 
+# worrying about silent errors
+#
+# Uses `[[`, not the data.table idiom, because this also has to run on sf
+# objects from st_read() -- data.table's `:=` strips the sfc column's
+# crs/bbox attributes. Plain `[` won't work either: data.table overloads
+# dt[character_columns] as a join, not column selection, so `[[` in a loop
+# is the one form that behaves the same on both data.table and sf.
+normalize_missing_strings <- function(data) {
+  character_columns <- names(data)[vapply(data, is.character, logical(1))]
+  for (column_name in character_columns) {
+    data[[column_name]] <- replace(data[[column_name]], data[[column_name]] == "", NA_character_)
+  }
+  return(data)
+}
+
+# fread(), with the same blank -> NA cleanup get_shape_data() does for shapefiles.
+safe_fread <- function(...) {
+  normalize_missing_strings(fread(...))
+}
+
 ######## Shape read / crop chain ########
 
 # read a shapefile and reproject it to crs_projection
@@ -23,6 +49,7 @@ DEMO_BG_FOLDER <- "block group demographics"
 get_shape_data <- function(shape_file_path, crs_projection = CRS_PROJECTION) {
   shape_data <- st_read(shape_file_path)
   shape_data <- st_transform(shape_data, crs_projection)
+  shape_data <- normalize_missing_strings(shape_data)
   return(shape_data)
 }
 

--- a/R/result_analysis/utility_functions/precinct_shape_functions.r
+++ b/R/result_analysis/utility_functions/precinct_shape_functions.r
@@ -194,7 +194,7 @@ flag_unpopulated_precincts <- function(as_provided_precincts, block_precinct_ass
 # location
 flag_populated_unassigned_blocks <- function(block_precinct_assignment) {
   unassigned_populated_blocks <- block_precinct_assignment %>%
-    mutate(unassigned_populated = population > 0 & (is.na(USER_POLL_) | USER_POLL_ == ""))
+    mutate(unassigned_populated = population > 0 & is.na(USER_POLL_))
 
   #write to file
   st_write(
@@ -323,7 +323,7 @@ reconcile_state_precinct_data <- function(precinct_file, precinct_column_names,
                                            location_name_col, address_col,
                                            state_precincts, county_name, location) {
   #read in county provided data
-  provided_polls <- fread(precinct_file)
+  provided_polls <- safe_fread(precinct_file)
 
   #validate the columns indicated in the config against columns in provided data
   precinct_column_numbers <- which(names(provided_polls) %in% precinct_column_names)
@@ -377,8 +377,6 @@ build_precinct_crosswalk <- function(reviewed_corrections) {
   # use the name from the (user corrected) USER_POLL_ column
   # unassigned polling locations are kept as NAs
   crosswalk <- reviewed_corrections[ , resolved_polling_location := USER_POLL_
-                ][is.na(USER_POLL_) | USER_POLL_ == "",
-                resolved_polling_location := NA_character_
                 ][resolution_type == "rename" | resolution_type ==  "drop" ,
                 .(Precinct_I, resolved_polling_location) ]
 
@@ -556,7 +554,7 @@ get_driving_distances <- function(block_precinct_assignment, state_county_crossw
     by.y = c("id_orig", "id_dest_upper"), all.x = TRUE)
 
   #alert if there are missing distances or times for blocks with associated polling locations
-  missing_distances <- distance_blocks[(is.na(distance_m) | is.na(duration_s)) & !(is.na(resolved_destination) | resolved_destination == ''), ]
+  missing_distances <- distance_blocks[(is.na(distance_m) | is.na(duration_s)) & !is.na(resolved_destination), ]
   if (nrow(missing_distances)>0){
     stop(paste('The following blocks do not have driving distances: ', paste(missing_distances$GEOID20, collapse = ', ')))
   }


### PR DESCRIPTION
## Summary
- PR #329 explicitly deferred this: fwrite()/st_write() both serialize NA_character_ as a blank cell, but fread()'s default na.strings only recognizes literal "NA" text, and st_read() has no equivalent option at all since DBF has no real NULL. This let a genuinely-dropped precinct's NA destination silently round-trip back as `""` through the crosswalk CSV, papered over by `is.na(x) | x == ''` guards reimplemented at each call site that happened to notice.
- Adds `normalize_missing_strings()` / `safe_fread()` to `city_shape_functions.r`, wires them into `get_shape_data()` (covers every shapefile read in the precinct pipeline) and every `fread()`/`st_read()` call carrying a missing-destination column: `reconcile_state_precinct_data()`, `extract_precincts.r`'s mismatches/crosswalk/block-assignment reads, and `Monongalia_reconciliation.r`.
- Simplifies the three now-redundant `is.na(x) | x == ''` guards in `precinct_shape_functions.r` down to `is.na(x)`.

## Why read-side, not write-side
Considered `fwrite(na = "NA")` instead, but rejected it: it only covers the CSV path, does nothing for `st_read()`/DBF (which can't write anything but blank for NA regardless), and risks colliding with any string data that's ever literally the text `"NA"`. Normalizing once on the read side works uniformly across both file formats.

## Test plan
- [x] All four changed files parse as valid R (`parse()` check).
- [x] `Rscript R/tests/r_smoke_test.R` passes.
- [x] Manual verification script exercising `normalize_missing_strings()` on both a `data.table` and an `sf` object, `safe_fread()` round-tripping a real `fwrite()`-serialized NA, and `build_precinct_crosswalk()` producing a real `NA` (not `""`) for a dropped precinct's destination.
- [ ] Full pipeline (`flag_state_provided_precincts.r` -> `Monongalia_reconciliation.r` -> `extract_precincts.r`) re-run against real Monongalia data, since no automated test suite covers these R analysis scripts (per `R/CLAUDE.md`).

## Related
- Base is #329 -- this was called out there as a gap the author wanted a read on before committing to a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)