### PR TITLE
feat(r-analysis): upload precinct analysis runs as session snapshots (#340)

### DIFF
--- a/R/result_analysis/Basic_analysis_configs/Monongalia_County_original.r
+++ b/R/result_analysis/Basic_analysis_configs/Monongalia_County_original.r
@@ -1,0 +1,60 @@
+#######
+#Analysis Constants
+#######
+
+#Basic constants for analysis
+#LOCATION must be either a string or list of strings
+#ORIG_CONFIG_FOLDER must be a string
+#POTENTIAL_CONFIG_FOLDER must either be a string or NULL
+#                   NULL indicates that this set of constants is only
+#                   on for historical
+
+
+LOCATION = 'Monongalia_County_WV' #needed only for reading from csv and writing outputs
+ORIG_CONFIG_FOLDER = "Monongalia_County_WV_driving_original_configs"
+POTENTIAL_CONFIG_FOLDER = NULL #leave NULL if only want historical analysis
+ORIG_FIELD_OF_INTEREST = '' #must not leave empty if config set has only one element
+POTENTIAL_FIELD_OF_INTEREST = '' #must not leave empty if config set has only one element
+
+if (is.null(POTENTIAL_CONFIG_FOLDER)){
+    HISTORICAL_FLAG = TRUE
+}else{HISTORICAL_FLAG = FALSE}
+
+DEMOGRAPHIC_LIST = c('white', 'black')
+
+#Run-type specific constants
+#24 = unique id_dest count in the metric_driving_time results CSV (matches the
+#24 dissolved features in the solver precinct shapefile built from it)
+IDEAL_POLL_NUMBER  = 24
+
+#dictionary of custom descriptors
+#keys: automatatically generated descriptor values to change
+#values: the desired descriptor values
+#If no changes desired, set
+DESCRIPTOR_DICT_ORIG <-NULL
+DESCRIPTOR_DICT_POTENTIAL <- NULL
+
+
+#######
+#Constants for DB
+#######
+
+# This is where this analysis will be stored in the cloud
+STORAGE_BUCKET = 'equitable-polling-analysis'
+if (HISTORICAL_FLAG){
+    CLOUD_STORAGE_ANALYSIS_NAME = paste(ORIG_CONFIG_FOLDER, 'HISTORICAL')
+}else{
+    CLOUD_STORAGE_ANALYSIS_NAME = paste0(ORIG_CONFIG_FOLDER, '_AND_', POTENTIAL_CONFIG_FOLDER)
+}
+
+#constants for reading data
+READ_FROM_CSV = TRUE
+PRINT_SQL = FALSE
+
+#Connect to database if needed
+#returns NULL if READ_FROM_CSV = TRUE
+POLLING_CON <- define_connection()
+
+
+#constants for how graphs and maps should be made
+LINEAR_COLOR_GRADIENT = FALSE #should the maps have a log or linear color scale

--- a/R/result_analysis/precinct_configs/Monongalia_County_WV.r
+++ b/R/result_analysis/precinct_configs/Monongalia_County_WV.r
@@ -55,3 +55,12 @@ SOLVER_PRECINCT_SHAPEFILE <- "result_analysis_outputs/Monongalia_County_WV_drivi
 # Demographic groups for density-vs-distance graphs
 ########
 DEMOGRAPHIC_LIST <- c("population")
+
+########
+# Cloud storage
+########
+# Precinct analyses upload under their own top-level folder in the bucket,
+# beside the Basic_analysis folder (see #335 / #340).
+STORAGE_BASE_DIR <- "precinct-distance-analyses"
+STORAGE_BUCKET <- "equitable-polling-analysis"
+CLOUD_STORAGE_ANALYSIS_NAME <- paste0(LOCATION, "_precinct_analysis")

--- a/R/result_analysis/precinct_configs/Monongalia_County_WV_no_precinct_data.r
+++ b/R/result_analysis/precinct_configs/Monongalia_County_WV_no_precinct_data.r
@@ -52,7 +52,21 @@ BLOCK_GEOMETRY_FILES <- "tl_2020_54061_tabblock20"
 ########
 OPTIMIZATION_RESULTS <- 'datasets/results/Monongalia_County_WV_results/Monongalia_County_WV_driving_original_configs.Monongalia_County_WV_metric_driving_time_results.csv'
 
+# solver-optimized precinct shapefile, written by make_precinct_map() as part
+# of Basic_analysis.r's workflow -- rerun that script for this county/config
+# if OPTIMIZATION_RESULTS changes, to keep this in sync.
+SOLVER_PRECINCT_SHAPEFILE <- "result_analysis_outputs/Monongalia_County_WV_driving_original_configs/Monongalia_County_WV_precinct_metric_driving_time.shp"
+
 ########
 # Demographic groups for density-vs-distance graphs
 ########
 DEMOGRAPHIC_LIST <- c("population")
+
+########
+# Cloud storage
+########
+# Precinct analyses upload under their own top-level folder in the bucket,
+# beside the Basic_analysis folder (see #335 / #340).
+STORAGE_BASE_DIR <- "precinct-distance-analyses"
+STORAGE_BUCKET <- "equitable-polling-analysis"
+CLOUD_STORAGE_ANALYSIS_NAME <- paste0(LOCATION, "_precinct_analysis")

--- a/R/result_analysis/scripts/extract_precincts.r
+++ b/R/result_analysis/scripts/extract_precincts.r
@@ -18,18 +18,18 @@ source("R/result_analysis/utility_functions/regression_functions.r")
 # this file.
 #######
 
-#args <- commandArgs(trailingOnly = TRUE)
-#if (length(args) != 1) {
-#  stop("Must enter exactly one config file")
-#} else {
-#  config_path <- paste0("R/result_analysis/precinct_configs/", args[1])
-#  source(config_path)
-#}
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 1) {
+  stop("Must enter exactly one config file")
+} else {
+  config_path <- paste0("R/result_analysis/precinct_configs/", args[1])
+  source(config_path)
+}
 
 ###
 # For inline testing only
 ###
-source("R/result_analysis/precinct_configs/Monongalia_County_WV.r")
+#source("R/result_analysis/precinct_configs/Monongalia_County_WV.r")
 
 #define output folder. 
 precinct_analysis_output_folder <- file.path("precinct_analysis_outputs", LOCATION)
@@ -84,16 +84,35 @@ block_demographics <- get_block_demographics(p3_file_path, p4_file_path)
 
 #read in driving distances
 driving_distance_path <- build_driving_distances_file_path(LOCATION)
+add_source_to_graph_file_manifest("driving_distances", driving_distance_path)
 driving_distances <- fread(driving_distance_path)
 driving_distances[, id_orig := as.character(id_orig)]
 driving_distances[, id_dest_upper := toupper(id_dest)]
 
 #read in optimization results (used for both duration thresholds below)
+add_source_to_graph_file_manifest("optimization_results", OPTIMIZATION_RESULTS)
+#record the config the results file came from. The filename is
+#<config_set>.<config_name>_results.csv and is the only provenance a CSV
+#carries -- no config id, and no model_run_id (both are database concepts).
+results_file_stem <- sub("_results\\.csv$", "", basename(OPTIMIZATION_RESULTS))
+add_config_info_to_graph_file_manifest(
+  "",
+  sub("\\..*$", "", results_file_stem),
+  sub("^[^.]*\\.", "", results_file_stem)
+)
 optimization_results <- fread(
   OPTIMIZATION_RESULTS, colClasses = list(character = "id_orig")
 )
 
-#read the solver-optimized precinct shapefile, for Step 7's maps
+#read the solver-optimized precinct shapefile, for Step 7's maps.
+#Register it and its sidecars as sources: until #333 has this script build
+#the outlines itself, they are consumed Basic_analysis output.
+for (shapefile_part in paste0(sub("\\.shp$", "", SOLVER_PRECINCT_SHAPEFILE),
+                              c(".shp", ".dbf", ".shx", ".prj"))) {
+  if (file.exists(shapefile_part)) {
+    add_source_to_graph_file_manifest("solver_precinct_shapefile", shapefile_part)
+  }
+}
 solver_precinct_shapes <- get_solver_precinct_shapes(
   SOLVER_PRECINCT_SHAPEFILE, OPTIMIZATION_RESULTS
 )
@@ -245,3 +264,7 @@ plot_density_v_distance_bg(
   solver_regression_data, LOCATION, DEMOGRAPHIC_LIST,
   log_flag = FALSE, driving_flag = TRUE, y_bounds = shared_density_y_bounds
 )
+
+###### Step 9: upload this session's outputs and sources to cloud storage #######
+
+upload_graph_files_to_cloud_storage()

--- a/R/result_analysis/utility_functions/precinct_shape_functions.r
+++ b/R/result_analysis/utility_functions/precinct_shape_functions.r
@@ -606,6 +606,7 @@ flag_distant_blocks <- function(distance_demographic_blocks, duration_threshold_
   demographic_blocks_for_csv[, id_orig := force_text_for_spreadsheet(id_orig)]
 
   fwrite(demographic_blocks_for_csv, distance_flagged_blocks_path)
+  add_graph_to_graph_file_manifest(distance_flagged_blocks_path)
 
   return(flagged_data)
 }
@@ -713,6 +714,7 @@ flagged_optimized_distant_blocks <- function(block_shapes, optimization_results,
   results_for_csv <- copy(results)
   results_for_csv[, id_orig := force_text_for_spreadsheet(id_orig)]
   fwrite(results_for_csv, distance_flagged_blocks_path)
+  add_graph_to_graph_file_manifest(distance_flagged_blocks_path)
 
   return(results)
 }
@@ -854,6 +856,7 @@ make_demo_distance_heat_map <- function(
     collapse = "_"
   )
   ggsave(file_name, heat_map, width = 10, height = 8)
+  add_graph_to_graph_file_manifest(file_name)
 
   return()
 }

--- a/R/result_analysis/utility_functions/storage.R
+++ b/R/result_analysis/utility_functions/storage.R
@@ -46,6 +46,10 @@ create_graph_file_manifest <- function() {
         # relative to ("result_analysis_outputs" or "precinct_analysis_outputs").
         # Set by the first add_graph_to_graph_file_manifest call.
         output_tree = NULL,
+        # Input files the analysis consumed, registered by
+        # add_source_to_graph_file_manifest. Each entry records a role, the
+        # repo-relative path it came from, and its cloud object name.
+        sources = list(),
         # The date and time this analsis was run
         created_at = now(tzone = "UTC")
 	)
@@ -90,10 +94,8 @@ add_model_run_id_to_graph_file_manifest <- function(model_run_id) {
 # config_set: string of the config set
 # config_name: string of the config name
 add_config_info_to_graph_file_manifest <- function(config_id, config_set, config_name) {
-    if (nchar(config_id) == 0) {
-		# Handle null or empty string cases
-		stop(paste0("add_config_info_to_graph_file_manifest got an invalid config_id ", config_id))
-	}
+    # config_id may be empty: it is a database concept, and configs recovered
+    # from a results CSV filename carry only config_set and config_name.
 
     if (nchar(config_set) == 0) {
 		# Handle null or empty string cases
@@ -165,6 +167,49 @@ add_graph_to_graph_file_manifest <- function(graph_file) {
     graph_file_path
 }
 
+# Register an input file the analysis consumed. Unlike graph files, sources
+# may live anywhere under the repo root (e.g. datasets/driving/); they upload
+# under sources/<basename> beside the graphs, so the uploaded folder holds
+# everything a reader needs to reproduce the analysis.
+#
+# role: short label for what the file is (e.g. "driving_distances")
+# source_file: path to the file, relative paths resolved against getwd()
+add_source_to_graph_file_manifest <- function(role, source_file) {
+    if (nchar(role) == 0 || nchar(source_file) <= 1) {
+        stop(paste0("add_source_to_graph_file_manifest got an invalid role or path: '",
+                    role, "' '", source_file, "'"))
+    }
+    source_path <- file.path(getwd(), source_file)
+    root_prefix <- paste0(here(), "/")
+    if (!startsWith(source_path, root_prefix)) {
+        stop(paste0("cannot record source file ", source_path,
+                    " -- not under the repo root ", here()))
+    }
+    if (!file.exists(source_path)) {
+        stop(paste0("cannot record source file ", source_path,
+                    " -- file does not exist"))
+    }
+
+    # Init .graph_file_manifest if it doesn't already exist
+	get_graph_file_manifest()
+
+    origin <- substring(source_path, nchar(root_prefix) + 1)
+    source_entry <- list(
+        role = role,
+        origin = origin,
+        object_name = paste0("sources/", basename(source_path))
+    )
+
+    already_recorded <- any(sapply(.graph_file_manifest$sources,
+                                   function(existing) existing$origin == origin))
+    if (!already_recorded) {
+        num_sources <- length(.graph_file_manifest$sources)
+        .graph_file_manifest$sources[[num_sources + 1]] <<- source_entry
+    }
+
+    source_entry
+}
+
 # Uploads all files in the manifest to Google Cloud Storage.
 upload_graph_files_to_cloud_storage <- function() {
     manifest = get_graph_file_manifest()
@@ -205,6 +250,19 @@ upload_graph_files_to_cloud_storage <- function() {
             gcs_upload(file=local_file_path, bucket=STORAGE_BUCKET, name=cloud_storage_file_name, predefinedAcl=STORAGE_PREDEFINED_ACL)
         } else {
             stop(paste0("upload_graph_files_to_cloud_storage cannot find file ", local_file_path))
+        }
+    }
+
+    # Upload each consumed input recorded in sources
+    for (source_entry in manifest$sources) {
+        local_file_path <- file.path(here(), source_entry$origin)
+        cloud_storage_file_name <- paste(cloud_storage_base_path, source_entry$object_name, sep="/")
+
+        if (file.exists(local_file_path)) {
+            print(paste0("Uploading file ", local_file_path, " -> ", STORAGE_BUCKET, ":", cloud_storage_file_name))
+            gcs_upload(file=local_file_path, bucket=STORAGE_BUCKET, name=cloud_storage_file_name, predefinedAcl=STORAGE_PREDEFINED_ACL)
+        } else {
+            stop(paste0("upload_graph_files_to_cloud_storage cannot find source file ", local_file_path))
         }
     }
 


### PR DESCRIPTION
Plain summary: a precinct analysis run now uploads everything it produced and the input files
it used to its own top-level folder in the analyses bucket, `precinct-distance-analyses/`,
beside the existing Basic_analysis folder. A reader can reproduce the analysis from that
folder alone. Decided at the 08-17 meeting; this is "PR 2" of the plan on #335 and the first
half of #340. Basic_analysis uploads are untouched. Stacked on #341 (PR 1), which it depends
on — the diff here shows only this PR's commit.

**Merge with a merge commit, not a squash.** Merge #341 first; this PR's base then moves to
`feature/generalize_storage.R`.

## What changed (6 files, +180/−13)

- **`storage.R`** — the manifest gains a `sources` list, filled by a new
  `add_source_to_graph_file_manifest(role, path)`: a source may live anywhere under the repo
  root, must exist at registration, and uploads as `sources/<basename>` beside the graphs.
  The config-id guard is relaxed — an id may be empty (it is a database concept) while
  config set and name stay required — so a config recovered from a results filename can be
  recorded.
- **`extract_precincts.r`** — the command-line config argument is restored (the inline
  test line is commented out, as in `Basic_analysis.r`). The script registers its inputs:
  the driving-distance file, the optimization-results CSV, and — until #333 has this script
  build the outlines itself — the Basic_analysis solver shapefile with its sidecars. It
  records the config set and name parsed from the results filename, and ends with the
  upload call. The optimal-assignments piece still runs on every run; making it optional
  is the follow-up on #340 and waits on the plan's questions 10a/c/d.
- **`precinct_shape_functions.r`** — the two flagged-block CSV writers and the heat-map
  writer register their outputs, so the manifest lists every file the run produced.
- **Configs** — both runnable precinct configs gain `STORAGE_BASE_DIR`, `STORAGE_BUCKET`,
  and `CLOUD_STORAGE_ANALYSIS_NAME` (`<LOCATION>_precinct_analysis`); the `no_precinct_data`
  variant gains its missing `SOLVER_PRECINCT_SHAPEFILE`; the Monongalia Basic_analysis
  config that produces that shapefile is committed (`IDEAL_POLL_NUMBER = 24`, the unique
  destination count in the results CSV; the value is currently unused by
  `Basic_analysis.r`).

Resulting layout for one run:

```
precinct-distance-analyses/Monongalia_County_WV_precinct_analysis/<datestamp>/
├── analysis_manifest.yaml
├── Monongalia_County_WV/            (14 outputs: 8 heat maps, 4 flagged CSVs, 2 density plots)
└── sources/                         (distance file, results CSV, solver shapefile + sidecars)
```

## Test plan

- [x] End-to-end run of `extract_precincts.r Monongalia_County_WV_no_precinct_data.r` with
      a stubbed `gcs_upload`: 21 uploads (14 outputs, 6 sources, manifest last) under the
      expected folder; every manifest entry equals its object name; `STORAGE_BASE_DIR` and
      bucket taken from the config; configs recorded from the results filename.
      (The county-provided-data branch of Step 2 was not exercised: it reads
      `temp/Precincts_by_Location.csv`, which exists only on the data author's machine — a
      pre-existing reproducibility gap, unchanged by this PR. Both configs carry identical
      storage constants, so the storage behavior under test is the same either way.)
- [x] Uploaded manifest YAML parsed back: `output_tree`, 6 complete `sources` entries
      (role / origin / object name), config with empty id, 14 `graph_files`.
- [x] PR 1 harness re-run green against the extended `storage.R`.
- [x] `Rscript R/tests/r_smoke_test.R`
- [x] Real `gcs_upload()` exercised 2026-08-24 (UTC) against the scratch bucket
      `equitable-polling-analysis-scratch`: the full e2e run uploaded all 21 objects at
      exactly the manifest's names (including filenames with spaces), the downloaded
      `analysis_manifest.yaml` was byte-identical to the local serialization and parsed
      cleanly outside R, and the test prefix was deleted (bucket confirmed back to its
      pre-run object count).

Reader note: an empty `model_run_ids` serializes as YAML `null` rather than `[]` (standard
R `c()` behavior) — manifest consumers should treat `null` as empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
