### PR TITLE
fix(database): import empty required-string CSV fields as '' not the string 'nan' (#348)

### DIFF
--- a/python/database/imports.py
+++ b/python/database/imports.py
@@ -94,10 +94,11 @@ def load_model_csv(
 
     Reads the CSV without enforcing types so that raw values are available for validation.
     Each column is then matched to its model counterpart (honoring column_renames) and
-    converted with the appropriate typed converter. Two validations run per column:
+    converted with the appropriate typed converter. Three checks run per column:
 
     1. Non-nullable numeric columns are checked for nulls before conversion.
-    2. Type conversion errors are caught and re-raised with the exact CSV line number,
+    2. Empty cells in non-nullable string columns are normalized to '' before conversion.
+    3. Type conversion errors are caught and re-raised with the exact CSV line number,
        column name, and failing value to simplify debugging malformed source files.
 
     Args:
@@ -160,6 +161,17 @@ def load_model_csv(
                         f'Line: {line_number}\n'
                         f'Expected Type: {expected_type}'
                     )
+
+            # Normalize empty cells in non-nullable string columns to ''. That matches the
+            # established convention in production for empty required strings (e.g. the
+            # blank addresses on centroid rows). It has to happen here, where column
+            # nullability is known: pandas reads an empty cell as NaN, csv_str_converter's
+            # emptiness check misses it because bool(NaN) is True, and set_column_types'
+            # astype(str) then renders it as the literal string 'nan'. Nullable string
+            # columns are deliberately left alone -- what an empty value means there is a
+            # per-column question nobody currently hits, so no blanket rule is imposed.
+            elif model_column not in nullable_columns:
+                df[csv_column] = df[csv_column].fillna('')
 
             try:
                 df[csv_column] = df[csv_column].apply(converter)

--- a/python/tests/imports_test.py
+++ b/python/tests/imports_test.py
@@ -29,6 +29,14 @@ class _NonNullableFloatModel(_TestBase):
     value = Column(Float, nullable=False)
 
 
+class _NonNullableStringModel(_TestBase):
+    ''' Test model with a non-nullable string column. '''
+    __tablename__ = 'test_non_nullable_string'
+    id = Column(String(36), primary_key=True)
+    name = Column(String(256))
+    address = Column(String(256), nullable=False)
+
+
 def test_load_model_csv_results(test_results_path):
     ''' Valid results CSV loads with correct shape and types. '''
     df = imports.load_model_csv(models.Result, {}, test_results_path)
@@ -111,6 +119,22 @@ def test_load_model_csv_null_in_non_nullable_float_raises(tmp_path):
 
     with pytest.raises(ValueError, match=r'Unexpected null value'):
         imports.load_model_csv(_NonNullableFloatModel, {}, csv_path)
+
+
+def test_load_model_csv_empty_non_nullable_string_becomes_empty_string(tmp_path):
+    ''' Empty value in a non-nullable string column imports as '' and never as 'nan'. '''
+    csv_path = os.path.join(tmp_path, 'empty_string.csv')
+    pd.DataFrame({
+        'id': ['a', 'b', 'c'],
+        'name': ['x', 'y', 'z'],
+        'address': ['123 Main St', None, '456 Oak Ave'],
+    }).to_csv(csv_path, index=False)
+
+    df = imports.load_model_csv(_NonNullableStringModel, {}, csv_path)
+    df = imports.set_column_types(df, _NonNullableStringModel)
+
+    assert df.loc[1, 'address'] == ''
+    assert df.loc[1, 'address'] != 'nan'
 
 
 def test_load_model_csv_null_error_reports_line_number(tmp_path):


### PR DESCRIPTION
Plain summary: when a CSV import reads an empty cell in a required text column, the value
currently lands in the database as the literal string `"nan"` instead of `''`. This fixes
that at the one point in the import chain where column nullability is known, scoped to
non-nullable string columns only, with the test the suite was missing. Closes #348.

## Background

Regression from the March import rework: pandas reads an empty cell as NaN,
`csv_str_converter`'s emptiness check misses it (`bool(NaN)` is `True`), and
`set_column_types`' `astype(str)` renders it as the string `"nan"`, which satisfies
NOT NULL. Prod evidence (read-only queries, details on #347/#348): all pre-2026 distance
sets store empty addresses as `''` (62.1M rows — the established convention); the `"nan"`
form appears only in the two 2026 Bartow sets. Found during the #347 Tarrant backfill
pre-run review; the backfill cherry-picks this commit locally, so it is not blocked on
this PR's merge.

## Scoping

- `csv_str_converter` untouched (other callers; no blanket rule).
- Nullable string columns deliberately unchanged — what an empty value means there is a
  per-column question nobody currently hits (noted in the code comment).
- `set_column_types` and `validate_csv_columns` untouched.

## Test plan

- [x] TDD: `test_load_model_csv_empty_non_nullable_string_becomes_empty_string` fails on
      unmodified dev (`assert 'nan' == ''`), passes with the fix; asserts through
      `set_column_types`, i.e. the full chain that minted the `'nan'`.
- [x] Both existing numeric-null tests still pass.
- [x] Full suite from the worktree: 197 passed, 19 skipped (the e2e_db set, no
      settings.yaml).
- [x] e2e_db run separately with credentials: 212 passed; 4 pre-existing failures
      reproduced identically on clean `origin/dev` — unrelated schema drift in the shared
      `tests_chad` dataset (`duration_s` column from the driving-time branch; tracked
      separately).
- [x] `pylint python/`: 9.77, all pre-existing findings; no new disables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
