### PR TITLE
Make #325 branch comments readable: docstring/comment accuracy pass + minor code fixes

### DIFF
--- a/docs/to_run.md
+++ b/docs/to_run.md
@@ -113,7 +113,7 @@ Both Gwinnett_G**A**_configs/Gwinnett* and Gwinnett_G**a**_configs/Gwinnett* wil
 
 ## Generating driving distances
 
-The solver consumes driving-distance CSVs at `datasets/driving/<Loc>_<ST>/<Loc>_<ST>_driving_distances.csv`. The `generate_driving_distances_cli` script builds those CSVs from existing project data (TIGER block centroids + the `<Loc>_<ST>_potential_locations.csv` already used by the solver) by routing every origin × destination pair through a locally-hosted OpenRouteService (ORS) container.
+The solver consumes driving-distance CSVs at `datasets/driving/<Loc>_<ST>/<Loc>_<ST>_driving_distances.csv`. The `generate_driving_distances_cli` script builds those CSVs from existing project data (TIGER block centroids + the `<Loc>_<ST>_potential_locations.csv` already used by the solver) by routing every origin × destination pair through a locally-hosted OpenRouteService (ORS) container. **USAGE NOTE:** This CLI is designed to only take local config, `<Loc>_<ST>_potential_locations` and census files, not to read from the database or make census pulls. See [input_files.md](input_files.md)for more information on generating or obtaining these files.
 
 ```bash
 python3 run.py generate_driving_distances_cli \
@@ -136,16 +136,8 @@ State slugs are full Geofabrik names (`georgia`, `new-york`, `district-of-columb
 
 ### Unroutable origins fail the run
 
-Every populated census block needs a real driving distance for the solver to run, so an origin ORS cannot route is an error, not a warning. When any origin is unrouted, the CLI still writes the CSV with everything that was successfully computed (completed work is never lost), then **exits non-zero** and prints each missing origin with its id and lat/lon. Fix the underlying data (typically a bad block centroid) and rerun — the resume logic reads the existing CSV and fetches only the missing pairs. Rows patched into the CSV by hand are likewise recognized as satisfied on the next run.
+Every populated census block needs a real driving distance for the solver to run, so an origin ORS cannot route is an error, not a warning. When any origin is unrouted, the CLI still writes the CSV with everything that was successfully computed (completed work is never lost), then **exits non-zero** and prints each missing origin with its id and lat/lon. Fix the underlying data (typically a bad block centroid) and rerun — the resume logic reads the existing CSV and fetches only the missing pairs. Rows patched into the CSV by hand are likewise recognized as satisfied on the next run. Note the check is origin-level: an origin that routes to some destinations but not others is not flagged here; that gap is caught downstream at model-run time. TODO: update after #338 is implemented.
 
-### Pre-flight probe: `--check-bad-locations`
-
-```bash
-python3 run.py generate_driving_distances_cli --check-bad-locations \
-  -l datasets/configs/<config_set>/<config>.yaml
-```
-
-Probe-only mode: performs the same ORS routing but writes **no** output CSV, then reports unroutable origins and exits non-zero if it found any (0 when all origins routed). Useful as a pre-flight check when onboarding a new county — it surfaces bad centroids before you commit to treating a generated matrix as final. Note the check is origin-level: an origin that routes to some destinations but not others is not flagged here; that gap is caught downstream at model-run time.
 
 ### Manual lifecycle (debugging / repeated experiments)
 

--- a/docs/to_run.md
+++ b/docs/to_run.md
@@ -113,7 +113,7 @@ Both Gwinnett_G**A**_configs/Gwinnett* and Gwinnett_G**a**_configs/Gwinnett* wil
 
 ## Generating driving distances
 
-The solver consumes driving-distance CSVs at `datasets/driving/<Loc>_<ST>/<Loc>_<ST>_driving_distances.csv`. The `generate_driving_distances_cli` script builds those CSVs from existing project data (TIGER block centroids + the `<Loc>_<ST>_potential_locations.csv` already used by the solver) by routing every origin × destination pair through a locally-hosted OpenRouteService (ORS) container. **USAGE NOTE:** This CLI is designed to only take local config, `<Loc>_<ST>_potential_locations` and census files, not to read from the database or make census pulls. See [input_files.md](input_files.md)for more information on generating or obtaining these files.
+The solver consumes driving-distance CSVs at `datasets/driving/<Loc>_<ST>/<Loc>_<ST>_driving_distances.csv`. The `generate_driving_distances_cli` script builds those CSVs from existing project data (TIGER block centroids + the `<Loc>_<ST>_potential_locations.csv` already used by the solver) by routing every origin × destination pair through a locally-hosted OpenRouteService (ORS) container. **USAGE NOTE:** This CLI is designed to only take local config, `<Loc>_<ST>_potential_locations` and census files, not to read from the database or make census pulls. See [input_files.md](input_files.md) for more information on generating or obtaining these files.
 
 ```bash
 python3 run.py generate_driving_distances_cli \

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -32,6 +32,8 @@ When code is changed or refactored, update any affected docstrings to stay accur
 
 Inline comments should explain *why*, not restate *what* the code does. Keep them concise and follow PEP 8 (single space after `#`, sentence case).
 
+One exception: a short **signpost** — a noun/verb phrase, not a sentence — may mark the start of a multi-line phase in a function long enough that skimming it cold is hard. Signposts mark phases, not statements: if the block is a single self-documenting call (e.g. `_reject_negative_distances(df)`), a signpost just restates the function name and should be deleted, not shortened. One per phase. Rationale still belongs at the phase's own definition — a function's docstring — never repeated at the call site.
+
 ## Test-Driven Development
 
 All code must be written using TDD:

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -34,6 +34,10 @@ Inline comments should explain *why*, not restate *what* the code does. Keep the
 
 One exception: a short **signpost** — a noun/verb phrase, not a sentence — may mark the start of a multi-line phase in a function long enough that skimming it cold is hard. Signposts mark phases, not statements: if the block is a single self-documenting call (e.g. `_reject_negative_distances(df)`), a signpost just restates the function name and should be deleted, not shortened. One per phase. Rationale still belongs at the phase's own definition — a function's docstring — never repeated at the call site.
 
+A comment can be specific and falsifiable and still misattribute *why* — e.g. attributing a rejection rule to the specific algorithm consuming the data, when the rule is actually a general data-integrity constraint the algorithm has nothing to do with. Check that the named mechanism is the right one, not just that *some* mechanism is named.
+
+A test's docstring should describe what the test verifies, not re-derive why the underlying code behaves that way — that reasoning belongs at the production code's own definition, not the test.
+
 ## Test-Driven Development
 
 All code must be written using TDD:
@@ -43,6 +47,10 @@ All code must be written using TDD:
 3. **Refactor** — clean up while keeping all tests green.
 
 When modifying existing code, update the associated tests before or alongside the change, and confirm all relevant tests pass before considering the work done.
+
+When deleting or consolidating tests, verify every assertion is covered elsewhere first — not just the ones tied to your reason for removing it. Also check for exact duplicates hiding under different names when merging test classes.
+
+A test whose entire premise guards a since-deleted code path has no value even if its assertions still pass — delete it rather than patching its literal values to keep it green.
 
 ## Key Conventions
 

--- a/python/scripts/generate_driving_distances_cli.py
+++ b/python/scripts/generate_driving_distances_cli.py
@@ -19,6 +19,8 @@ from python.solver.constants import (
     DISTANCE_DISTANCE_M,
     DISTANCE_ID_DEST,
     DISTANCE_ID_ORIG,
+    POT_LOC_LAT_LON,
+    POT_LOC_LOCATION,
     TIGER20_GEOID20,
     TIGER20_INTPTLAT20,
     TIGER20_INTPTLON20,
@@ -113,12 +115,8 @@ def derive_origins_and_destinations(config):
     locations = dict(zip(source_ids, coords))
 
     # get destination id and location coordinates from potential_location data
-    destination_ids = potential_locations_df['Location'].tolist()
-    malformed_coordinates = potential_locations_df['Lat, Lon'].str.count(',') != 1
-    if malformed_coordinates.any():
-        bad = potential_locations_df.loc[malformed_coordinates, 'Lat, Lon'].tolist()
-        raise ValueError(f'Lat, Lon column: expected exactly one comma per value, got: {bad}')
-    joint_coords = potential_locations_df['Lat, Lon'].str.split(',', expand=True).astype(float)
+    destination_ids = potential_locations_df[POT_LOC_LOCATION].tolist()
+    joint_coords = potential_locations_df[POT_LOC_LAT_LON].str.split(',', expand=True).astype(float)
     dest_coords = joint_coords[[1, 0]].values.tolist()  # column 0 is lat, column 1 is lon — reorder to [lon, lat]
     locations.update(dict(zip(destination_ids, dest_coords)))
 

--- a/python/scripts/generate_driving_distances_cli.py
+++ b/python/scripts/generate_driving_distances_cli.py
@@ -1,9 +1,9 @@
 '''CLI: generate the driving-distance CSV for a given county config.
 
-Reads census block centroids and the potential-locations CSV the solver
-consumes, calls OpenRouteService to build a driving-distance matrix, and
-writes the canonical three-column long-form CSV to
-``datasets/driving/<location>/<location>_driving_distances.csv``.
+Reads census block centroids and the potential-locations CSV from disk
+(no DB read or census pulls enabled), calls OpenRouteService to build a 
+driving-distance matrix, and writes the canonical three-column long-form 
+CSV to ``datasets/driving/<location>/<location>_driving_distances.csv``.
 '''
 import argparse
 import os
@@ -28,8 +28,8 @@ from python.solver.model_data import get_blocks_gdf, load_potential_locations_cs
 from python.utils.directory_constants import DRIVING_DIR
 from python.utils.driving_distance_matrix import (
     build_distance_matrix,
-    get_missing_origins,
-    resume_from_partial_output,
+    get_origins_with_blank_distances,
+    identify_unmatched_pairs,
 )
 from python.utils.ors_setup import GEOFABRIK_STATE_SLUGS, state_slug_from_location
 from python.utils.ors_url import resolve_ors_url
@@ -37,21 +37,24 @@ from python.utils.utils import build_potential_locations_file_path, log_date_pre
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
-    '''Return the CLI argument parser.'''
-    # A separate function (unlike older sibling CLIs that parse inline) so
-    # tests can exercise parsing directly, per this repo's TDD mandate.
+    '''Return the CLI argument parser. Split out into its own function
+    so it can have its own unit test, complying with updated testing standards.'''
+
     parser = argparse.ArgumentParser(
-        description='Generate driving-distance CSV for a county config.',
+        description='Generate driving-distance CSV for a county config. Requires the '
+        'relevant config files and potential_locations data to be stored locally (not on the DB) '
+        'and that the relevant TIGER files are already on disk.',
     )
+    # testing fixtures are a sample of Gwinnett County, 2020 data
+    # these have no state (_<ST>) suffix
+    # this flag accommodates this anomaly.
     parser.add_argument(
         '--state', default=None,
-        # The override exists because not every config location can derive a
-        # state: the 'testing' fixture's location has no _<ST> suffix. It also
-        # lets an operator deliberately point at a different state's graph.
         help='Geofabrik state slug override (e.g. "georgia", "new-york"). '
              'When omitted, derived by parsing the trailing _<ST> postal code '
              'from the config location.',
     )
+    #path to config argument
     parser.add_argument(
         '-l', '--location-config', required=True,
         help=(
@@ -60,17 +63,16 @@ def build_arg_parser() -> argparse.ArgumentParser:
             'path form accepted by model_run_cli.'
         ),
     )
+    #set ORS urls
     parser.add_argument(
         '--server', default=None,
         help='ORS matrix endpoint URL (overrides $ORS_URL).',
     )
+    #logging
     parser.add_argument(
         '--logdir', default='./logs', help='Directory to write the run log into.',
     )
-    parser.add_argument(
-        '--check-bad-locations', action='store_true',
-        help='Probe-only mode: list unroutable origins and exit without writing output.',
-    )
+    #verbosity
     parser.add_argument(
         '-v', '--verbose', action='count', default=0,
         help='Increase screen verbosity (-v or -vv). The log file captures everything regardless.',
@@ -86,7 +88,8 @@ def build_output_csv_path(location: str) -> str:
 
 
 def derive_origins_and_destinations(config):
-    '''Build (locations_dict, source_ids, dest_ids) from the config.
+    '''Build (locations_dict, source_ids, dest_ids) from the config. This 
+    is the data format expected by ORS to build distance matrix.
 
     Args:
         config: A loaded ``PollingModelConfig``.
@@ -95,83 +98,31 @@ def derive_origins_and_destinations(config):
         A tuple ``(locations, source_ids, dest_ids)``:
             - ``locations``: ``id -> [longitude, latitude]`` dict.
             - ``source_ids``: census block GEOIDs (origins).
-            - ``dest_ids``: potential-location ``Location`` values (destinations).
+            - ``destination_ids``: potential-location ``Location`` values (destinations).
     '''
-    # Always reads local files, disregarding config.data_source — structural,
-    # not a choice: data_source is not a YAML field at all. load_config REJECTS
-    # a YAML that contains it (ValueError 'unknown fields' — IGNORE_ON_LOAD in
-    # python/solver/model_config.py excludes it from allowed_fields), so here
-    # the field always holds its DATA_SOURCE_CSV default. Only model_run_db_cli
-    # sets 'db', at runtime, as a came-from-the-DB provenance marker — and this
-    # CLI loads configs from YAML only. DB-backed generation would be a new
-    # feature (e.g. a generate_driving_distances_db_cli sibling, mirroring the
-    # model_run_cli / model_run_db_cli split).
+
+    # load local block geography and potential locations data.
     blocks_gdf = get_blocks_gdf(config.census_year, config.location)
-    pots_df = load_potential_locations_csv(
+    potential_locations_df = load_potential_locations_csv(
         build_potential_locations_file_path(config.location),
     )
 
-    locations = {}
-    source_ids = []
-    for _, row in blocks_gdf.iterrows():
-        geoid = str(row[TIGER20_GEOID20])
-        locations[geoid] = [float(row[TIGER20_INTPTLON20]), float(row[TIGER20_INTPTLAT20])]
-        source_ids.append(geoid)
+    # get source id and location data from TIGER
+    source_ids = blocks_gdf[TIGER20_GEOID20].astype(str).tolist()
+    coords = blocks_gdf[[TIGER20_INTPTLON20, TIGER20_INTPTLAT20]].astype(float).values.tolist()
+    locations = dict(zip(source_ids, coords))
 
-    extract_lon_lat = _pick_coord_extractor(list(pots_df.columns))
-    dest_ids = []
-    for _, row in pots_df.iterrows():
-        loc_id = str(row['Location'])
-        lon, lat = extract_lon_lat(row)
-        locations[loc_id] = [lon, lat]
-        dest_ids.append(loc_id)
+    # get destination id and location coordinates from potential_location data
+    destination_ids = potential_locations_df['Location'].tolist()
+    malformed_coordinates = potential_locations_df['Lat, Lon'].str.count(',') != 1
+    if malformed_coordinates.any():
+        bad = potential_locations_df.loc[malformed_coordinates, 'Lat, Lon'].tolist()
+        raise ValueError(f'Lat, Lon column: expected exactly one comma per value, got: {bad}')
+    joint_coords = potential_locations_df['Lat, Lon'].str.split(',', expand=True).astype(float)
+    dest_coords = joint_coords[[1, 0]].values.tolist()  # column 0 is lat, column 1 is lon — reorder to [lon, lat]
+    locations.update(dict(zip(destination_ids, dest_coords)))
 
-    return locations, source_ids, dest_ids
-
-
-def _pick_coord_extractor(columns):
-    '''Return a callable that reads ``(lon, lat)`` from a potential-locations row.
-
-    The project carries two CSV schemas in the wild:
-
-    - Separate ``Latitude`` / ``Longitude`` columns (e.g. the ``testing`` fixture).
-    - A single combined column named ``"Lat, Long"`` or ``"Lat, Lon"`` whose
-      value is a string like ``"32.707497 , -97.252456"`` (lat first, comma,
-      lon; tolerating whitespace) — used by Tarrant_County_TX.
-
-    Args:
-        columns: Sequence of column names from the loaded DataFrame.
-
-    Returns:
-        A callable ``extract(row) -> (lon, lat)`` for use in the dest loop.
-
-    Raises:
-        ValueError: If neither schema is present in the columns.
-    '''
-    if 'Longitude' in columns and 'Latitude' in columns:
-        def extract_separate(row):
-            return float(row['Longitude']), float(row['Latitude'])
-        return extract_separate
-
-    combined_col = next(
-        (col for col in columns if col.lower().replace(' ', '').startswith('lat,l')),
-        None,
-    )
-    if combined_col is not None:
-        def extract_combined(row):
-            value = str(row[combined_col])
-            parts = value.split(',')
-            if len(parts) != 2:
-                raise ValueError(
-                    f'Expected lat, lon format in combined column {combined_col!r}, got: {value!r}'
-                )
-            return float(parts[1].strip()), float(parts[0].strip())
-        return extract_combined
-
-    raise ValueError(
-        f'Potential-locations CSV has neither separate Latitude/Longitude '
-        f'columns nor a combined Lat, Lon column. Got columns: {list(columns)}'
-    )
+    return locations, source_ids, destination_ids
 
 
 def write_output_csv(df, path: str) -> None:
@@ -190,7 +141,7 @@ def _open_log_file(logdir: str, config_file_path: str):
 
 
 def _tee(message: str, log_fh, *, to_screen: bool = True) -> None:
-    '''Write ``message`` to stdout (optionally) and to ``log_fh``, flushing.'''
+    '''Write ``message`` to screen (optionally) and to ``log_fh``, flushing.'''
     if to_screen:
         print(message)
     log_fh.write(message + '\n')
@@ -221,7 +172,8 @@ def _assert_ors_reachable(matrix_url: str) -> None:
 
 
 def _origin_lines(origins: set[str], locations: dict[str, list[float]]) -> list[str]:
-    '''Return one indented ``id (lat=..., lon=...)`` line per origin, sorted by id.
+    '''Formatting function for _report_unrouted_origin's logging below.
+    Return one indented ``id (lat=..., lon=...)`` line per origin, sorted by id.
 
     Args:
         origins: Origin ids to list.
@@ -232,7 +184,7 @@ def _origin_lines(origins: set[str], locations: dict[str, list[float]]) -> list[
     '''
     lines = []
     for origin in sorted(origins):
-        longitude, latitude = locations.get(origin, (None, None))
+        longitude, latitude = locations.get(origin, [None, None])
         lines.append(f'  {origin} (lat={latitude}, lon={longitude})')
     return lines
 
@@ -242,53 +194,56 @@ def _report_unrouted_origins(df: pd.DataFrame,
                              locations: dict[str, list[float]],
                              log_fh: TextIO,
                              *,
-                             output_path: str | None = None) -> set[str]:
-    '''Detect origins lacking a usable distance and print a mode-accurate summary.
+                             output_path: str) -> set[str]:
+    '''Detects origins that have not been properly filled by previous runs and provides
+    instructions on next steps. TODO: flagging only happens at origin level, not pair level. 
+    See docs/to_run.md (section "Unroutable origins fail the run") for details. see #338
 
-    Two failure shapes are distinguished: origins with no rows at all in
-    ``df`` (ORS could not route them), and origins whose rows carry a blank
-    ``distance_m`` — possible only via a hand-edited output CSV, and NOT
-    recovered by a plain rerun, because resume counts those pairs as present.
+    Two failure shapes are distinguished: absent origins with no rows at all recorded in the df
+    on file and blank origins whose rows carry a blank ``distance_m``. 
+    
+    Blank origins are caused by human editing of unroutable origins that need
+    to be entered manually or have the row deleted TODO: see #338.
+    
+    The absent origins are either due to an aborted run on generate_driving_distances_cli
+    or the existence of unroutable origins that cannot be automatically routed. These need 
+    human review.
 
     Args:
-        df: Long-form distance DataFrame to check — the build result in probe
-            mode, or the just-written frame in the write paths.
+        df: Long-form distance DataFrame to check 
         source_ids: All requested origin ids.
         locations: Mapping from id to ``[longitude, latitude]``, used to print
             each missing origin's coordinates.
         log_fh: Open writable log file handle.
         output_path: Path of the output CSV that was just written, named in
-            the failure message. ``None`` in probe mode, where no CSV exists
-            and the message must not reference one (or resume).
-
+            the failure message.
+        
     Returns:
         The set of origin ids lacking a usable distance; empty when every
         origin has one.
     '''
-    blank_origins = get_missing_origins(df)
+    #define the two missing modes this function deals with:
+    blank_origins = get_origins_with_blank_distances(df)
     absent_origins = set(source_ids) - set(df[DISTANCE_ID_ORIG])
+
     unrouted = blank_origins | absent_origins
     if not unrouted:
-        return unrouted
+        return unrouted # nothing unrouted — every origin has a usable distance
 
+    #otherwise log missing data
     lines = []
-    if output_path is None:
-        lines.append(f'{len(unrouted)} origin(s) could not be routed; correct the '
-                     'underlying data (e.g. a bad centroid) and re-run the probe:')
-        lines.extend(_origin_lines(unrouted, locations))
-    else:
-        if absent_origins:
-            lines.append(f'{len(absent_origins)} origin(s) could not be routed and have '
-                         f'no rows in {output_path}; correct the underlying data (e.g. a '
-                         'bad centroid) and rerun — resume will fetch only the missing '
-                         'pairs:')
-            lines.extend(_origin_lines(absent_origins, locations))
-        if blank_origins:
-            lines.append(f'{len(blank_origins)} origin(s) in the existing CSV '
-                         f'({output_path}) have a blank distance_m; fill in the value, or '
-                         'delete the row so resume re-fetches it — rerunning without a '
-                         'change will NOT fetch these pairs:')
-            lines.extend(_origin_lines(blank_origins, locations))
+    if absent_origins:
+        lines.append(f'{len(absent_origins)} origin(s) could not be routed and have '
+                        f'no rows in {output_path}; correct the underlying data (e.g. a '
+                        'bad centroid) and rerun — resume will fetch only the missing '
+                        'pairs:')
+        lines.extend(_origin_lines(absent_origins, locations))
+    if blank_origins:
+        lines.append(f'{len(blank_origins)} origin(s) in the existing CSV '
+                        f'({output_path}) have a blank distance_m; fill in the value, or '
+                        'delete the row so resume re-fetches it — rerunning without a '
+                        'change will NOT fetch these pairs:')
+        lines.extend(_origin_lines(blank_origins, locations))
     _tee('\n'.join(lines), log_fh)
     return unrouted
 
@@ -317,30 +272,29 @@ def main(argv=None):
     Returns:
         ``0`` on success; ``1`` when any requested origin lacks a usable
         distance — either ORS could not route it, or its row in the existing
-        output CSV has a blank ``distance_m`` (in the normal mode the CSV of
-        completed work is still written first). Exits via ``sys.exit(main())``
+        output CSV has a blank ``distance_m``. Exits via ``sys.exit(main())``
         from the if __name__ block.
     '''
     args = build_arg_parser().parse_args(argv)
 
-    # Validate an explicit --state before any ORS or config work, so a typo
-    # fails fast without requiring a running ORS or a readable config file.
+    # Validate an explicit --state for testing fixtures
     if args.state is not None:
         _reject_unknown_slug(args.state)
 
+    #check url
     matrix_url = resolve_ors_url(args.server)
     _assert_ors_reachable(matrix_url)
 
+    #load config
     config = PollingModelConfig.load_config(args.location_config)
 
+    #check state validity before ORS run
     state = args.state
     if state is None:
         try:
             state = state_slug_from_location(config.location)
         except ValueError as exc:
-            # Expected for synthetic configs whose location field doesn't follow
-            # the <Name>_<ST> convention — e.g. the 'testing' fixture — which is
-            # the case that motivated the --state override in the first place.
+            # Expected exception for the 'testing' fixture
             print(
                 f'Couldn\'t derive state from config (location={config.location!r}; {exc}).\n'
                 f'Either rename the location to end in _<ST> '
@@ -350,6 +304,8 @@ def main(argv=None):
             )
             sys.exit(2)
     _reject_unknown_slug(state)
+
+    #begin logging.
     log_fh, log_path = _open_log_file(args.logdir, config.config_file_path)
     try:
         _tee(f'[{datetime.now().isoformat(timespec="seconds")}] starting for '
@@ -361,46 +317,33 @@ def main(argv=None):
 
         _tee(f'ORS matrix URL: {matrix_url}', log_fh)
 
-        if args.check_bad_locations:
-            _tee('check-bad-locations mode: probing only, no output written', log_fh)
-            df = build_distance_matrix(
-                locations=locations, source_ids=source_ids, dest_ids=dest_ids,
-                matrix_url=matrix_url,
-                log_fh=log_fh, verbosity=args.verbose,
-            )
-            # TODO(#325): detection here is origin-level — an origin that routes
-            # to some destinations but not others (pair-level incompleteness) is
-            # not flagged here; it is caught downstream at model-run time by
-            # model_data's completeness check. Known gap, deliberately not fixed
-            # in this ticket.
-            if _report_unrouted_origins(df, source_ids, locations, log_fh):
-                return 1
-            _tee('no unroutable origins found', log_fh)
-            return 0
+        ###create and write distance matrix###
 
+        #identify missing data if any
         output_path = build_output_csv_path(config.location)
-        existing_df, remaining_pairs = resume_from_partial_output(
+        existing_df, remaining_pairs = identify_unmatched_pairs(
             output_path, source_ids, dest_ids,
         )
         _tee(
             f'resume: {len(existing_df)} rows present, '
-            f'{len(remaining_pairs)} pairs to fetch',
+            f'{len(remaining_pairs)} pairs to fetch', 
             log_fh,
         )
-
+        #if all origins destination pairs are in the dataset
         if not remaining_pairs:
             write_output_csv(existing_df, output_path)
             _tee(
                 f'no new pairs to fetch; rewrote {len(existing_df)} rows to {output_path}',
                 log_fh,
             )
-            # A hand-edited CSV can satisfy every pair yet leave distance_m
-            # blank — still a failure the solver would hit later.
+            #verify that they have distances entered.
             if _report_unrouted_origins(existing_df, source_ids, locations, log_fh,
                                         output_path=output_path):
                 return 1
             return 0
 
+        #otherwise, some pairs are missing.
+        #try to fetch these pairs
         remaining_sources = sorted({pair[0] for pair in remaining_pairs})
         remaining_dests = sorted({pair[1] for pair in remaining_pairs})
         new_df = build_distance_matrix(
@@ -411,16 +354,15 @@ def main(argv=None):
             log_fh=log_fh, verbosity=args.verbose,
         )
 
+        #concatenate results and drop duplicates
         combined = pd.concat([existing_df, new_df], ignore_index=True)
         combined = combined.drop_duplicates(
             subset=[DISTANCE_ID_ORIG, DISTANCE_ID_DEST], keep='last',
         )
 
+        #write outputs and report missing data
         write_output_csv(combined, output_path)
         _tee(f'wrote {len(combined)} rows to {output_path}', log_fh)
-        # The CSV is written first so completed work is never lost: on a
-        # failure here, a human fixes the flagged origins and reruns, and
-        # resume fetches only the missing pairs.
         if _report_unrouted_origins(combined, source_ids, locations, log_fh,
                                     output_path=output_path):
             return 1

--- a/python/solver/model_data.py
+++ b/python/solver/model_data.py
@@ -470,10 +470,11 @@ def insert_driving_distances(
 
     Raises
     ValueError - if driving_distances_df is missing any of the id_orig, id_dest, or
-        distance_m COLUMNS. Row-level completeness (every populated block having a
-        valid distance) is NOT checked here — the left join leaves nulls for absent
-        pairs; filter_distance_data enforces completeness at model-run time, raising
-        'Some distances are missing or invalid (negative) for current config setting.'
+        distance_m COLUMNS. 
+    
+    Notes
+    This function does not check for for row level completeness. filter_distance_data enforces 
+    completeness at model-run time
 
     Returns
     The original dataframe with the distance_m column populated with the driving distances.
@@ -697,8 +698,7 @@ def filter_dest_type(distance_df: pd.DataFrame, year_list: list[str]):
     )
 
 
-# pylint: disable-next=unused-argument
-def filter_distance_data(config: PollingModelConfig, distance_df: pd.DataFrame, for_alpha: bool, log: bool):
+def filter_distance_data(config: PollingModelConfig, distance_df: pd.DataFrame, for_alpha: bool):
     '''
     Reads the intermediate data frame from file, and pull the relevant rows.
     Notes:
@@ -752,11 +752,7 @@ def filter_distance_data(config: PollingModelConfig, distance_df: pd.DataFrame, 
     if any(pop_df>1):
         raise ValueError(f'Some id_orig has multiple associated populations from {config.config_file_path}')
 
-    # Raise error if any distance is missing or invalid. A distance is invalid
-    # if it is null or negative. 0 is a legitimate same-point distance and stays
-    # valid; a negative distance is never a real-world value, and because the KP
-    # objective minimizes distance the solver would treat it as more attractive
-    # than 0 -- so reject it like a missing value.
+    # Raise error if any distance is missing or negative.
     invalid_mask = (
         pd.isnull(filtered_distance_df.distance_m)
         | (filtered_distance_df.distance_m < 0)

--- a/python/solver/model_run.py
+++ b/python/solver/model_run.py
@@ -184,10 +184,10 @@ class ModelRun():
         distance_df = distance_data.distance_df
 
         # get main data frame
-        dist_df = filter_distance_data(self._config, distance_df, False, self._log)
+        dist_df = filter_distance_data(self._config, distance_df, False)
 
         # get alpha
-        alpha_df = filter_distance_data(self._config, distance_df, True, self._log)
+        alpha_df = filter_distance_data(self._config, distance_df, True)
         alpha = alpha_min(alpha_df)
 
         # build model

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -147,11 +147,11 @@ def polling_locations_df(testing_config_base):
 
 @pytest.fixture(scope='module')
 def clean_distances_df(testing_config_base, polling_locations_df):
-    yield model_data.filter_distance_data(testing_config_base, polling_locations_df, False, False)
+    yield model_data.filter_distance_data(testing_config_base, polling_locations_df, False)
 
 @pytest.fixture(scope='module')
 def alpha_min(testing_config_base, polling_locations_df):
-    alpha_df = model_data.filter_distance_data(testing_config_base, polling_locations_df, True, False)
+    alpha_df = model_data.filter_distance_data(testing_config_base, polling_locations_df, True)
     yield model_data.alpha_min(alpha_df)
 
 @pytest.fixture(scope='module')

--- a/python/tests/driving_distance_matrix_test.py
+++ b/python/tests/driving_distance_matrix_test.py
@@ -15,14 +15,14 @@ from python.utils.driving_distance_matrix import (
     _emit,
     _reject_negative_distances,
     build_distance_matrix,
-    get_missing_origins,
+    get_origins_with_blank_distances,
     matrix_response_to_long_df,
-    resume_from_partial_output,
+    identify_unmatched_pairs,
 )
 from python.utils.ors_client import OrsMatrixError
 
 
-class TestGetMissingOrigins:
+class TestGetOriginsWithBlankDistances:
     '''Identify origins with any null driving distance.'''
 
     def test_returns_origins_with_at_least_one_null(self):
@@ -31,7 +31,7 @@ class TestGetMissingOrigins:
             'id_dest': ['x', 'y', 'x', 'y', 'x'],
             'distance_m': [10.0, None, 20.0, 30.0, None],
         })
-        assert get_missing_origins(df) == {'a', 'c'}
+        assert get_origins_with_blank_distances(df) == {'a', 'c'}
 
     def test_returns_empty_set_when_none_missing(self):
         df = pd.DataFrame({
@@ -39,7 +39,7 @@ class TestGetMissingOrigins:
             'id_dest': ['x', 'x'],
             'distance_m': [10.0, 20.0],
         })
-        assert get_missing_origins(df) == set()
+        assert get_origins_with_blank_distances(df) == set()
 
 
 class TestMatrixResponseToLongDf:
@@ -139,20 +139,12 @@ class TestBuildDistanceMatrix:
 
 
 class TestUnroutableOriginsAreDropped:
-    '''An unroutable origin yields no rows — never a fabricated estimate (#325).'''
+    '''An unroutable origin yields no rows — never a fabricated estimate.'''
 
     @patch('python.utils.driving_distance_matrix.query_matrix')
     def test_unroutable_origin_rows_are_dropped_not_fabricated(self, mock_query):
-        '''Even with a routable origin ~111 m away, no distance is invented.
-
-        The haversine snap fallback was removed per #325: a fabricated
-        distance is indistinguishable from a real route in the output.
-        Callers detect dropped origins by comparing requested source_ids
-        against the returned id_orig values and must fail loud.
-        '''
-        # s1 is ~111 m north of s0 — the old snap path would have borrowed
-        # s0's route and fabricated a row for s1.
-        mock_query.return_value = [[100.0], [np.nan]]
+        '''An origin ORS cannot route gets no row at all — not null, not estimated.'''
+        mock_query.return_value = [[100.0], [np.nan]] # s0 routes, s1 doesn't
         log_fh = io.StringIO()
         df = build_distance_matrix(
             locations={
@@ -167,11 +159,10 @@ class TestUnroutableOriginsAreDropped:
         )
         assert set(df['id_orig']) == {'s0'}
         assert df['distance_m'].notna().all()
-        assert 'snapped' not in log_fh.getvalue()
 
 
-class TestResumeFromPartialOutput:
-    '''Partial-CSV resume: keep pairs already populated, fetch only the delta.'''
+class TestIdentifyUnmatchedPairs:
+    '''Identify (id_orig, id_dest) pairs missing from an existing output CSV.'''
 
     def test_returns_existing_pairs_unchanged_and_remaining_pairs_to_fetch(self, tmp_path):
         existing_csv = tmp_path / 'partial.csv'
@@ -181,7 +172,7 @@ class TestResumeFromPartialOutput:
             'distance_m': [100.0, 200.0],
         }).to_csv(existing_csv, index=False)
 
-        existing_df, remaining_pairs = resume_from_partial_output(
+        existing_df, remaining_pairs = identify_unmatched_pairs(
             existing_csv,
             source_ids=['a', 'b'],
             dest_ids=['x', 'y'],
@@ -191,7 +182,7 @@ class TestResumeFromPartialOutput:
         assert set(remaining_pairs) == {('b', 'x'), ('b', 'y')}
 
     def test_returns_empty_existing_when_file_absent(self, tmp_path):
-        existing_df, remaining_pairs = resume_from_partial_output(
+        existing_df, remaining_pairs = identify_unmatched_pairs(
             tmp_path / 'absent.csv',
             source_ids=['a'],
             dest_ids=['x'],
@@ -200,7 +191,7 @@ class TestResumeFromPartialOutput:
         assert set(remaining_pairs) == {('a', 'x')}
 
     def test_numeric_geoids_already_present_are_recognized(self, tmp_path):
-        '''Numeric-looking GEOIDs must match str source_ids so resume skips them.
+        '''Numeric-looking GEOIDs must match str source_ids so they're recognized as already present.
 
         Regression for #305: pd.read_csv infers id_orig as int64 for numeric
         census-block GEOIDs, so the present-pair check never matched the str
@@ -215,7 +206,7 @@ class TestResumeFromPartialOutput:
             'distance_m': [100.0, 200.0],
         }).to_csv(existing_csv, index=False)
 
-        existing_df, remaining_pairs = resume_from_partial_output(
+        existing_df, remaining_pairs = identify_unmatched_pairs(
             existing_csv,
             source_ids=['540610120004019'],
             dest_ids=['University High School', 'Triune-Halleck VFD'],

--- a/python/tests/driving_distance_matrix_test.py
+++ b/python/tests/driving_distance_matrix_test.py
@@ -21,6 +21,14 @@ from python.utils.driving_distance_matrix import (
 )
 from python.utils.ors_client import OrsMatrixError
 
+# Two origins, one destination — coordinates are arbitrary; not exercised
+# by anything using this constant.
+SAMPLE_LOCATIONS = {
+    's0': [-84.0000, 33.9500],
+    's1': [-84.0000, 33.9510],
+    'd':  [-84.1000, 34.0000],
+}
+
 
 class TestGetOriginsWithBlankDistances:
     '''Identify origins with any null driving distance.'''
@@ -147,11 +155,7 @@ class TestUnroutableOriginsAreDropped:
         mock_query.return_value = [[100.0], [np.nan]] # s0 routes, s1 doesn't
         log_fh = io.StringIO()
         df = build_distance_matrix(
-            locations={
-                's0': [-84.0000, 33.9500],
-                's1': [-84.0000, 33.9510],
-                'd':  [-84.1000, 34.0000],
-            },
+            locations=SAMPLE_LOCATIONS,
             source_ids=['s0', 's1'],
             dest_ids=['d'],
             matrix_url='http://ors:8082/ors/v2/matrix/driving-car',
@@ -192,12 +196,8 @@ class TestIdentifyUnmatchedPairs:
 
     def test_numeric_geoids_already_present_are_recognized(self, tmp_path):
         '''Numeric-looking GEOIDs must match str source_ids so they're recognized as already present.
-
-        Regression for #305: pd.read_csv infers id_orig as int64 for numeric
-        census-block GEOIDs, so the present-pair check never matched the str
-        source_ids built by the CLI. Every pair looked "remaining" and got
-        re-fetched, then survived drop_duplicates as a duplicate row (one int
-        key from the old file, one str key freshly fetched).
+        pd.read_csv infers id_orig as int64 for numeric census-block GEOIDs, silently preventing a match
+        due to type mismatch.
         '''
         existing_csv = tmp_path / 'partial.csv'
         pd.DataFrame({
@@ -343,11 +343,7 @@ class TestBuildMatrixNegativeHandling:
         mock_query.return_value = [[100.0], [-1.0]]
         with pytest.raises(ValueError, match='negative'):
             build_distance_matrix(
-                locations={
-                    's0': [-84.0000, 33.9500],
-                    's1': [-84.0000, 33.9510],  # ~111m north of s0
-                    'd':  [-84.1000, 34.0000],
-                },
+                locations=SAMPLE_LOCATIONS,
                 source_ids=['s0', 's1'],
                 dest_ids=['d'],
                 matrix_url='http://ors:8082/ors/v2/matrix/driving-car',

--- a/python/tests/generate_driving_distances_cli_test.py
+++ b/python/tests/generate_driving_distances_cli_test.py
@@ -96,6 +96,7 @@ class TestDeriveOriginsAndDestinations:
 
     @patch('python.scripts.generate_driving_distances_cli.load_potential_locations_csv')
     @patch('python.scripts.generate_driving_distances_cli.get_blocks_gdf')
+    #####TODO: Danger Will Robinson, Danger! Danger! what is this test supposed to do? 
     def test_handles_combined_lat_lon_column(self, mock_blocks, mock_pots):
         '''Tarrant_County_TX-style CSV uses a single "Lat, Long" column with "lat , lon" values.'''
         mock_blocks.return_value = pd.DataFrame({

--- a/python/tests/generate_driving_distances_cli_test.py
+++ b/python/tests/generate_driving_distances_cli_test.py
@@ -12,6 +12,13 @@ from python.scripts.generate_driving_distances_cli import (
     main,
     write_output_csv,
 )
+from python.solver.constants import (
+    POT_LOC_LAT_LON,
+    POT_LOC_LOCATION,
+    TIGER20_GEOID20,
+    TIGER20_INTPTLAT20,
+    TIGER20_INTPTLON20,
+)
 
 
 class TestArgParser:
@@ -77,13 +84,13 @@ class TestDeriveOriginsAndDestinations:
     def test_handles_combined_lat_lon_column(self, mock_blocks, mock_pots):
         '''Split a single "Lat, Lon" column into [lon, lat] values.'''
         mock_blocks.return_value = pd.DataFrame({
-            'GEOID20': ['111'],
-            'INTPTLAT20': ['32.7'],
-            'INTPTLON20': ['-97.3'],
+            TIGER20_GEOID20: ['111'],
+            TIGER20_INTPTLAT20: ['32.7'],
+            TIGER20_INTPTLON20: ['-97.3'],
         })
         mock_pots.return_value = pd.DataFrame({
-            'Location': ['pollA', 'pollB'],
-            'Lat, Lon': ['32.707497 , -97.252456', '32.711546, -97.189768'],
+            POT_LOC_LOCATION: ['pollA', 'pollB'],
+            POT_LOC_LAT_LON: ['32.707497 , -97.252456', '32.711546, -97.189768'],
         })
 
         config = MagicMock(location='Tarrant_County_TX', census_year='2020')
@@ -94,25 +101,6 @@ class TestDeriveOriginsAndDestinations:
         # ``[lon, lat]`` order — parser puts lon first.
         assert locations['pollA'] == [-97.252456, 32.707497]
         assert locations['pollB'] == [-97.189768, 32.711546]
-
-    @patch('python.scripts.generate_driving_distances_cli.load_potential_locations_csv')
-    @patch('python.scripts.generate_driving_distances_cli.get_blocks_gdf')
-    def test_raises_when_no_coord_columns(self, mock_blocks, mock_pots):
-        '''Neither separate Latitude/Longitude nor combined column → clear ValueError.'''
-        mock_blocks.return_value = pd.DataFrame({
-            'GEOID20': ['111'],
-            'INTPTLAT20': ['32.7'],
-            'INTPTLON20': ['-97.3'],
-        })
-        mock_pots.return_value = pd.DataFrame({
-            'Location': ['pollA'],
-            'Address': ['somewhere'],
-            # no coord columns at all
-        })
-
-        config = MagicMock(location='Tarrant_County_TX', census_year='2020')
-        with pytest.raises(ValueError, match='Latitude/Longitude'):
-            derive_origins_and_destinations(config)
 
 
 class TestMain:

--- a/python/tests/generate_driving_distances_cli_test.py
+++ b/python/tests/generate_driving_distances_cli_test.py
@@ -74,31 +74,8 @@ class TestDeriveOriginsAndDestinations:
 
     @patch('python.scripts.generate_driving_distances_cli.load_potential_locations_csv')
     @patch('python.scripts.generate_driving_distances_cli.get_blocks_gdf')
-    def test_returns_locations_dict_and_id_lists(self, mock_blocks, mock_pots):
-        # Mock the block centroid GeoDataFrame.
-        mock_blocks.return_value = pd.DataFrame({
-            'GEOID20': ['111', '222'],
-            'INTPTLAT20': ['33.9', '34.0'],
-            'INTPTLON20': ['-84.0', '-84.1'],
-        })
-        mock_pots.return_value = pd.DataFrame({
-            'Location': ['pollA', 'pollB'],
-            'Latitude': [33.95, 34.05],
-            'Longitude': [-84.05, -84.15],
-        })
-
-        config = MagicMock(location='Gwinnett_GA', census_year='2020')
-        locations, source_ids, dest_ids = derive_origins_and_destinations(config)
-        assert set(source_ids) == {'111', '222'}
-        assert set(dest_ids) == {'pollA', 'pollB'}
-        assert locations['111'] == [-84.0, 33.9]      # ``[lon, lat]`` order
-        assert locations['pollA'] == [-84.05, 33.95]
-
-    @patch('python.scripts.generate_driving_distances_cli.load_potential_locations_csv')
-    @patch('python.scripts.generate_driving_distances_cli.get_blocks_gdf')
-    #####TODO: Danger Will Robinson, Danger! Danger! what is this test supposed to do? 
     def test_handles_combined_lat_lon_column(self, mock_blocks, mock_pots):
-        '''Tarrant_County_TX-style CSV uses a single "Lat, Long" column with "lat , lon" values.'''
+        '''Split a single "Lat, Lon" column into [lon, lat] values.'''
         mock_blocks.return_value = pd.DataFrame({
             'GEOID20': ['111'],
             'INTPTLAT20': ['32.7'],
@@ -106,13 +83,14 @@ class TestDeriveOriginsAndDestinations:
         })
         mock_pots.return_value = pd.DataFrame({
             'Location': ['pollA', 'pollB'],
-            'Lat, Long': ['32.707497 , -97.252456', '32.711546,-97.189768'],  # both spacings
+            'Lat, Lon': ['32.707497 , -97.252456', '32.711546, -97.189768'],
         })
 
         config = MagicMock(location='Tarrant_County_TX', census_year='2020')
         locations, source_ids, dest_ids = derive_origins_and_destinations(config)
         assert set(source_ids) == {'111'}
         assert set(dest_ids) == {'pollA', 'pollB'}
+        assert locations['111'] == [-97.3, 32.7]
         # ``[lon, lat]`` order — parser puts lon first.
         assert locations['pollA'] == [-97.252456, 32.707497]
         assert locations['pollB'] == [-97.189768, 32.711546]
@@ -138,7 +116,7 @@ class TestDeriveOriginsAndDestinations:
 
 
 class TestMain:
-    '''Smoke-test the end-to-end flow with everything mocked.'''
+    '''Smoke-test the happy path end to end, everything mocked.'''
 
     @patch('python.scripts.generate_driving_distances_cli._assert_ors_reachable')
     @patch('python.scripts.generate_driving_distances_cli.build_distance_matrix')
@@ -180,150 +158,9 @@ class TestMain:
         assert list(written.columns) == ['id_orig', 'id_dest', 'distance_m']
         assert written.iloc[0]['distance_m'] == 12345.0
 
-    @patch('python.scripts.generate_driving_distances_cli._assert_ors_reachable')
-    @patch('python.scripts.generate_driving_distances_cli.build_distance_matrix')
-    @patch('python.scripts.generate_driving_distances_cli.derive_origins_and_destinations')
-    @patch('python.scripts.generate_driving_distances_cli.PollingModelConfig')
-    def test_check_bad_locations_exits_nonzero_and_lists_unrouted_origins(
-        self, mock_cfg_cls, mock_derive, mock_build, unused_mock_reach, tmp_path, capsys,
-    ):
-        '''--check-bad-locations writes no CSV; unrouted origins -> exit 1 + id/lat/lon.'''
-        del unused_mock_reach
-        mock_cfg_cls.load_config.return_value = MagicMock(
-            location='Gwinnett_GA', census_year='2020',
-            config_file_path=str(tmp_path / 'cfg.yaml'),
-        )
-        mock_derive.return_value = (
-            {
-                'block_ok': [-84.0, 33.9],
-                'block_bad': [-84.05, 33.91],
-                'poll_x': [-84.1, 34.0],
-            },
-            ['block_ok', 'block_bad'],   # block_bad absent from build result -> unrouted
-            ['poll_x'],
-        )
-        mock_build.return_value = pd.DataFrame({
-            'id_orig': ['block_ok'], 'id_dest': ['poll_x'], 'distance_m': [12345.0],
-        })
 
-        driving_dir = tmp_path / 'datasets' / 'driving' / 'Gwinnett_GA'
-        logdir = tmp_path / 'logs'
-        os.makedirs(logdir, exist_ok=True)
-        # build_output_csv_path is NEVER reached in this code path, but patch it
-        # anyway so a regression that wrongly fell through would still not touch
-        # the real filesystem.
-        expected_output = driving_dir / 'Gwinnett_GA_driving_distances.csv'
-
-        with patch(
-            'python.scripts.generate_driving_distances_cli.build_output_csv_path',
-            return_value=str(expected_output),
-        ):
-            rc = main([
-                '--state', 'georgia',
-                '-l', str(tmp_path / 'cfg.yaml'),
-                '--logdir', str(logdir),
-                '--check-bad-locations',
-            ])
-
-        assert rc == 1
-        assert not driving_dir.exists() or not expected_output.exists()
-        out = capsys.readouterr().out
-        assert 'could not be routed' in out
-        assert 'block_bad' in out
-        assert '33.91' in out       # latitude of the unrouted origin
-        assert '-84.05' in out      # longitude of the unrouted origin
-        # Probe mode writes no CSV, so the message must not reference one, nor
-        # promise anything about resume.
-        assert 'resume' not in out
-        assert str(expected_output) not in out
-
-    @patch('python.scripts.generate_driving_distances_cli._assert_ors_reachable')
-    @patch('python.scripts.generate_driving_distances_cli.build_distance_matrix')
-    @patch('python.scripts.generate_driving_distances_cli.derive_origins_and_destinations')
-    @patch('python.scripts.generate_driving_distances_cli.PollingModelConfig')
-    def test_check_bad_locations_exits_zero_when_all_routed(
-        self, mock_cfg_cls, mock_derive, mock_build, unused_mock_reach, tmp_path,
-    ):
-        '''--check-bad-locations exits 0 when every origin routed.'''
-        del unused_mock_reach
-        mock_cfg_cls.load_config.return_value = MagicMock(
-            location='Gwinnett_GA', census_year='2020',
-            config_file_path=str(tmp_path / 'cfg.yaml'),
-        )
-        mock_derive.return_value = (
-            {'block_ok': [-84.0, 33.9], 'poll_x': [-84.1, 34.0]},
-            ['block_ok'],
-            ['poll_x'],
-        )
-        mock_build.return_value = pd.DataFrame({
-            'id_orig': ['block_ok'], 'id_dest': ['poll_x'], 'distance_m': [12345.0],
-        })
-        logdir = tmp_path / 'logs'
-        os.makedirs(logdir, exist_ok=True)
-        rc = main([
-            '--state', 'georgia',
-            '-l', str(tmp_path / 'cfg.yaml'),
-            '--logdir', str(logdir),
-            '--check-bad-locations',
-        ])
-        assert rc == 0
-
-    @patch('python.scripts.generate_driving_distances_cli._assert_ors_reachable')
-    @patch('python.scripts.generate_driving_distances_cli.build_distance_matrix')
-    @patch('python.scripts.generate_driving_distances_cli.derive_origins_and_destinations')
-    @patch('python.scripts.generate_driving_distances_cli.PollingModelConfig')
-    def test_write_path_exits_nonzero_but_still_writes_partial_csv(
-        self, mock_cfg_cls, mock_derive, mock_build, unused_mock_reach, tmp_path, capsys,
-    ):
-        '''An unrouted origin fails the run loudly, but completed work is kept.
-
-        Per #325: write the partial CSV (composes with resume), exit non-zero,
-        and enumerate exactly which origins are missing with id + lat/lon.
-        '''
-        del unused_mock_reach
-        mock_cfg_cls.load_config.return_value = MagicMock(
-            location='Gwinnett_GA', census_year='2020',
-            config_file_path=str(tmp_path / 'cfg.yaml'),
-        )
-        mock_derive.return_value = (
-            {
-                'block_ok': [-84.0, 33.9],
-                'block_bad': [-84.05, 33.91],
-                'poll_x': [-84.1, 34.0],
-            },
-            ['block_ok', 'block_bad'],
-            ['poll_x'],
-        )
-        mock_build.return_value = pd.DataFrame({
-            'id_orig': ['block_ok'], 'id_dest': ['poll_x'], 'distance_m': [12345.0],
-        })
-
-        driving_dir = tmp_path / 'datasets' / 'driving' / 'Gwinnett_GA'
-        logdir = tmp_path / 'logs'
-        os.makedirs(driving_dir, exist_ok=True)
-        os.makedirs(logdir, exist_ok=True)
-        expected_output = driving_dir / 'Gwinnett_GA_driving_distances.csv'
-
-        with patch(
-            'python.scripts.generate_driving_distances_cli.build_output_csv_path',
-            return_value=str(expected_output),
-        ):
-            rc = main([
-                '--state', 'georgia',
-                '-l', str(tmp_path / 'cfg.yaml'),
-                '--logdir', str(logdir),
-            ])
-
-        assert rc == 1
-        # The partial CSV keeps the successfully routed rows.
-        written = pd.read_csv(expected_output)
-        assert set(written['id_orig']) == {'block_ok'}
-        out = capsys.readouterr().out
-        # The failure message names the CSV the missing rows are absent from.
-        assert f'no rows in {expected_output}' in out
-        assert 'block_bad' in out
-        assert '33.91' in out
-        assert '-84.05' in out
+class TestResumeBehavior:
+    '''Resume/partial-fetch mechanics: only the remaining pairs reach build_distance_matrix.'''
 
     @patch('python.scripts.generate_driving_distances_cli._assert_ors_reachable')
     @patch('python.scripts.generate_driving_distances_cli.build_distance_matrix')
@@ -417,6 +254,70 @@ class TestMain:
         assert rc == 0
         assert not mock_build.called
 
+
+class TestUnroutedOriginReporting:
+    '''_report_unrouted_origins fires correctly and the run exits non-zero, partial data kept.'''
+
+    @patch('python.scripts.generate_driving_distances_cli._assert_ors_reachable')
+    @patch('python.scripts.generate_driving_distances_cli.build_distance_matrix')
+    @patch('python.scripts.generate_driving_distances_cli.derive_origins_and_destinations')
+    @patch('python.scripts.generate_driving_distances_cli.PollingModelConfig')
+    def test_write_path_exits_nonzero_but_still_writes_partial_csv(
+        self, mock_cfg_cls, mock_derive, mock_build, unused_mock_reach, tmp_path, capsys,
+    ):
+        '''An unrouted origin fails the run loudly, but completed work is kept:
+        the partial CSV is written first, then the run exits non-zero and
+        enumerates exactly which origins are missing, with id and lat/lon.'''
+
+        del unused_mock_reach
+        #configure mocks: config, an origin that never gets routed, one good pair
+        mock_cfg_cls.load_config.return_value = MagicMock(
+            location='Gwinnett_GA', census_year='2020',
+            config_file_path=str(tmp_path / 'cfg.yaml'),
+        )
+        mock_derive.return_value = (
+            {
+                'block_ok': [-84.0, 33.9],
+                'block_bad': [-84.05, 33.91],
+                'poll_x': [-84.1, 34.0],
+            },
+            ['block_ok', 'block_bad'],
+            ['poll_x'],
+        )
+        mock_build.return_value = pd.DataFrame({
+            'id_orig': ['block_ok'], 'id_dest': ['poll_x'], 'distance_m': [12345.0],
+        })
+
+        #set up output and log paths under tmp_path
+        driving_dir = tmp_path / 'datasets' / 'driving' / 'Gwinnett_GA'
+        logdir = tmp_path / 'logs'
+        os.makedirs(driving_dir, exist_ok=True)
+        os.makedirs(logdir, exist_ok=True)
+        expected_output = driving_dir / 'Gwinnett_GA_driving_distances.csv'
+
+        #run the CLI
+        with patch(
+            'python.scripts.generate_driving_distances_cli.build_output_csv_path',
+            return_value=str(expected_output),
+        ):
+            rc = main([
+                '--state', 'georgia',
+                '-l', str(tmp_path / 'cfg.yaml'),
+                '--logdir', str(logdir),
+            ])
+
+        #verify: failure exit code, partial CSV kept, missing origin named in the message
+        assert rc == 1
+        # The partial CSV keeps the successfully routed rows.
+        written = pd.read_csv(expected_output)
+        assert set(written['id_orig']) == {'block_ok'}
+        out = capsys.readouterr().out
+        # The failure message names the CSV the missing rows are absent from.
+        assert f'no rows in {expected_output}' in out
+        assert 'block_bad' in out
+        assert '33.91' in out
+        assert '-84.05' in out
+
     @patch('python.scripts.generate_driving_distances_cli._assert_ors_reachable')
     @patch('python.scripts.generate_driving_distances_cli.build_distance_matrix')
     @patch('python.scripts.generate_driving_distances_cli.derive_origins_and_destinations')
@@ -424,11 +325,7 @@ class TestMain:
     def test_short_circuit_exits_nonzero_on_blank_distance_row(
         self, mock_cfg_cls, mock_derive, mock_build, unused_mock_reach, tmp_path, capsys,
     ):
-        '''A hand-edited blank distance_m must fail the no-new-pairs short-circuit.
-
-        Regression guard: resume counts a present-but-blank pair as satisfied,
-        so a plain rerun never re-fetches it — without this check the run
-        would exit 0 with an output the solver later rejects.
+        '''A blank distance_m must fail
         '''
         del unused_mock_reach
         mock_cfg_cls.load_config.return_value = MagicMock(
@@ -476,8 +373,8 @@ class TestMain:
         assert 'will NOT fetch' in out
 
 
-class TestStateValidation:
-    '''Tests for --state validation and config-derived fallback.'''
+class TestStateResolution:
+    '''Resolving --state: config-derived, explicit override, and validation.'''
 
     def test_rejects_unknown_state_slug(self, tmp_path):
         '''An explicit --state with an unknown slug must exit non-zero with a clear error.'''
@@ -485,19 +382,6 @@ class TestStateValidation:
         with pytest.raises(SystemExit) as exc_info:
             main(['--state', 'atlantis', '-l', '/nonexistent.yaml'])
         assert exc_info.value.code != 0
-
-    def test_state_flag_no_longer_required_on_cli(self):
-        '''argparse should accept --state-less invocation; derivation runs in main().'''
-        # This is the bare-parser case; the parser itself must accept it.
-        # main() will later try to load the config and derive; that error
-        # path is exercised by test_errors_when_neither_flag_nor_derivable_location.
-        parser = build_arg_parser()
-        args = parser.parse_args(['-l', '/nonexistent.yaml'])
-        assert args.state is None
-
-
-class TestConfigDerivedState:
-    '''Tests for deriving the state from config.location when --state is absent.'''
 
     @patch('python.scripts.generate_driving_distances_cli._assert_ors_reachable')
     @patch('python.scripts.generate_driving_distances_cli.build_distance_matrix')
@@ -543,6 +427,7 @@ class TestConfigDerivedState:
     @patch('python.scripts.generate_driving_distances_cli.build_distance_matrix')
     @patch('python.scripts.generate_driving_distances_cli.derive_origins_and_destinations')
     @patch('python.scripts.generate_driving_distances_cli.PollingModelConfig')
+    # TODO: DANGER Will Robinson. Danger! Danger! this is NOT desired behavior. See #350
     def test_explicit_state_flag_overrides_config_derivation(
             self, mock_cfg_cls, mock_derive, mock_build, unused_mock_reach, mock_state_derive, tmp_path):
         '''--state texas wins even when config.location would derive to georgia.

--- a/python/tests/model_data_test.py
+++ b/python/tests/model_data_test.py
@@ -134,7 +134,7 @@ def test_clean_data(testing_config_driving, location_df_with_driving):
     print(driving_locations_results_dest_types)
 
     # Check that clean_data removes bad types when for_alpha is False
-    cleaned_data_df = model_data.filter_distance_data(testing_config_driving, location_df_with_driving, False, False)
+    cleaned_data_df = model_data.filter_distance_data(testing_config_driving, location_df_with_driving, False)
     cleaned_data_bad_types_df = cleaned_data_df[cleaned_data_df['location_type'].isin(testing_config_driving.bad_types)]
     num_cleaned_bad_types = len(cleaned_data_bad_types_df)
 
@@ -143,7 +143,7 @@ def test_clean_data(testing_config_driving, location_df_with_driving):
     )
 
     # Check that clean_data with alpha set to true removes all location_types that contain 'Potential' or 'centroid'
-    cleaned_data_with_alpha_df = model_data.filter_distance_data(testing_config_driving, location_df_with_driving, True, False)
+    cleaned_data_with_alpha_df = model_data.filter_distance_data(testing_config_driving, location_df_with_driving, True)
     unique_location_types = cleaned_data_with_alpha_df['location_type'].unique()
 
     assert not any('Potential' in s or 'centroid' in s for s in unique_location_types), (
@@ -183,7 +183,7 @@ def test_filter_distance_data_raises_and_names_origin_on_negative(
     ''' A negative distance_m on a surviving row is rejected like a missing one. '''
     # Choose an origin that survives filtering, so the negative reaches the gate.
     surviving = model_data.filter_distance_data(
-        testing_config_driving, location_df_with_driving, False, False)
+        testing_config_driving, location_df_with_driving, False)
     bad_origin = surviving.iloc[0]['id_orig']
 
     poisoned = location_df_with_driving.copy(deep=True)
@@ -192,7 +192,7 @@ def test_filter_distance_data_raises_and_names_origin_on_negative(
     poisoned.loc[poisoned['id_orig'] == bad_origin, 'distance_m'] = -1.0
 
     with pytest.raises(ValueError):
-        model_data.filter_distance_data(testing_config_driving, poisoned, False, False)
+        model_data.filter_distance_data(testing_config_driving, poisoned, False)
     assert str(bad_origin) in capsys.readouterr().out
 
 
@@ -200,7 +200,7 @@ def test_filter_distance_data_raises_on_single_negative_cell(
         testing_config_driving, location_df_with_driving):
     ''' Even one negative cell on a surviving row triggers the gate. '''
     surviving = model_data.filter_distance_data(
-        testing_config_driving, location_df_with_driving, False, False)
+        testing_config_driving, location_df_with_driving, False)
     orig = surviving.iloc[0]['id_orig']
     dest = surviving.iloc[0]['id_dest']
 
@@ -209,14 +209,14 @@ def test_filter_distance_data_raises_on_single_negative_cell(
     poisoned.loc[cell, 'distance_m'] = -0.5
 
     with pytest.raises(ValueError):
-        model_data.filter_distance_data(testing_config_driving, poisoned, False, False)
+        model_data.filter_distance_data(testing_config_driving, poisoned, False)
 
 
 def test_filter_distance_data_allows_zero_distance(
         testing_config_driving, location_df_with_driving):
     ''' 0 is a legitimate same-point distance and must not raise. '''
     surviving = model_data.filter_distance_data(
-        testing_config_driving, location_df_with_driving, False, False)
+        testing_config_driving, location_df_with_driving, False)
     orig = surviving.iloc[0]['id_orig']
     dest = surviving.iloc[0]['id_dest']
 
@@ -225,5 +225,5 @@ def test_filter_distance_data_allows_zero_distance(
     df.loc[cell, 'distance_m'] = 0.0
 
     # Should not raise.
-    model_data.filter_distance_data(testing_config_driving, df, False, False)
+    model_data.filter_distance_data(testing_config_driving, df, False)
 

--- a/python/utils/driving_distance_matrix.py
+++ b/python/utils/driving_distance_matrix.py
@@ -312,7 +312,8 @@ def build_distance_matrix(*,
 def identify_unmatched_pairs(output_path, source_ids, dest_ids):
     '''Load an existing driving-distance CSV, if one exists, and identify the 
     (id_orig, id_dest) pairs from source_ids/dest_ids not yet present in it. 
-    Runs before the CLI queries ORS for the remaining pairs.
+    Presence is decided by the id columns only — a row with a blank
+    distance_m still counts as present. Runs before the CLI queries ORS for the remaining pairs.
 
     Args:
         output_path: Path to a possibly-existing CSV with columns

--- a/python/utils/driving_distance_matrix.py
+++ b/python/utils/driving_distance_matrix.py
@@ -1,10 +1,14 @@
 '''Orchestrate the building of a driving-distance matrix via ORS.
 
-This module batches ORS matrix calls, retries individual sources via the
-directions endpoint when a batch fails, and reshapes the ORS response into
-the project's canonical long-form CSV shape. Origins ORS cannot route are
-dropped from the result — never estimated — so callers can detect and fail
-loud on them (see #325).
+This module contains the batching and retry-on-failure protocols. 
+Batching and retries occur by source, not destination, for three reasons:
+there are more sources than destinations; sources are census block
+centroids that may not sit on a road; and destinations are already
+real, road-valid addresses. Each failed source is retried one
+origin/destination pair at a time. Furthermore, it drops unroutable
+rows, to avoid silent passing of these errors downstream. Finally,
+it reshapes the response to the desired long-form output.
+
 
 External callers should use ``build_distance_matrix``. The other functions
 are exposed for testing and for ad-hoc reuse.
@@ -50,7 +54,7 @@ def _emit(message: str, level: int, log_fh: TextIO, verbosity: int) -> None:
         print(message)
 
 
-def get_missing_origins(df: pd.DataFrame) -> set:
+def get_origins_with_blank_distances(df: pd.DataFrame) -> set:
     '''Return the set of origin ids that have any null driving distance.
 
     Args:
@@ -93,12 +97,9 @@ def matrix_response_to_long_df(source_names, dest_names, distances) -> pd.DataFr
 def _reject_negative_distances(df: pd.DataFrame) -> None:
     '''Raise if any ``distance_m`` is negative.
 
-    A negative driving distance is physically impossible, so it can only
-    signal a routing-backend error. Per the #294 decision, such a value fails
-    the run loudly here, at data generation, rather than being silently
-    recovered. A genuine "no route" arrives from ORS as null (NaN), not a
-    negative, and is left untouched; ``0`` is a valid distance (a residence at
-    its own polling place) and is also kept.
+    Guards against a negative driving distance appearing in the data matrix, 
+    which is a documented feature of some ORS versions. A "no route" response 
+    from ORS, represented as null (NaN), and a 0 distance are both kept.
 
     Args:
         df: Long-form DataFrame with a ``distance_m`` column.
@@ -250,10 +251,10 @@ def build_distance_matrix(*,
            cells (sources x dests).
         2. On batch failure (``OrsMatrixError``), defer the entire batch to
            per-source single-pair retries via the directions endpoint.
-        3. Pairs ORS still cannot route are dropped from the result — never
-           estimated. Callers detect dropped origins by comparing the
-           requested ``source_ids`` against the returned ``id_orig`` values
-           and must fail loud on any gap (see #325).
+        3. A pair ORS cannot route is dropped. This function does not raise or 
+        fail on a drop — the CLI compares requested source_ids against returned 
+        id_orig values and fails on any gap. see #338
+
 
     Args:
         locations: Mapping from id to ``[longitude, latitude]``.
@@ -274,6 +275,7 @@ def build_distance_matrix(*,
     source_ids = list(dict.fromkeys(source_ids))   # Dedup, preserve order.
     dest_ids = list(dict.fromkeys(dest_ids))
 
+    #run batches and concatenate
     batch_size = _batch_size(len(dest_ids))
     failed_sources = []
     batch_dfs = []
@@ -292,6 +294,7 @@ def build_distance_matrix(*,
         columns=[DISTANCE_ID_ORIG, DISTANCE_ID_DEST, DISTANCE_DISTANCE_M],
     )
 
+    #retry failed sources and concatenate
     if failed_sources:
         retry_df = _retry_sources_individually(
             failed_sources, dest_ids, locations, matrix_url,
@@ -299,28 +302,17 @@ def build_distance_matrix(*,
         )
         df = pd.concat([df, retry_df], ignore_index=True)
 
-    # Fail loud on negative distances (a routing-backend error) before any
-    # further processing, per the #294 decision. ORS signals a genuine
-    # no-route as null, never as a negative.
+    # Fail loud on negative distances
     _reject_negative_distances(df)
 
-    # Drop null (no-route) rows with no fabricated fallback (#325): a distance
-    # this code invented would be indistinguishable from a real route in the
-    # output. The caller compares requested source_ids against the returned
-    # id_orig values and fails loud so a human fixes the root cause.
+    # Drop null (no-route) rows
     return df.dropna(subset=[DISTANCE_DISTANCE_M]).reset_index(drop=True)
 
 
-def resume_from_partial_output(output_path, source_ids, dest_ids):
-    '''Return ``(existing_df, remaining_pairs)`` for resuming from a previous run's partial output CSV.
-
-    Loads an existing output CSV (if any) as a warm-start cache and computes
-    the ``(id_orig, id_dest)`` pairs not yet present in it. This lets a rerun
-    fetch only the delta when the origin/destination set has grown between
-    runs (e.g. a new potential polling location was added), and recognizes
-    rows a human hand-patched into the CSV (e.g. for a previously unrouted
-    origin) as satisfied instead of re-querying or clobbering them — the
-    prescribed recovery path after a fail-loud unrouted-origin run (#325).
+def identify_unmatched_pairs(output_path, source_ids, dest_ids):
+    '''Load an existing driving-distance CSV, if one exists, and identify the 
+    (id_orig, id_dest) pairs from source_ids/dest_ids not yet present in it. 
+    Runs before the CLI queries ORS for the remaining pairs.
 
     Args:
         output_path: Path to a possibly-existing CSV with columns


### PR DESCRIPTION
## Summary

This is primarily a comment/docstring readability pass on top of `fix/325-unrouted-origin-handling` (PR #337) — going line by line through the files that branch touches, verifying every claim a comment or docstring makes against the actual code/git/issue history, and fixing what didn't hold up. Also removes `--check-bad-locations` entirely, resolving #325's own deferred "keep vs remove" question.

**Everything in this diff beyond the two tables below is a comment, docstring, or test-docstring change** — wording, accuracy, or removing stale/unverified claims. No behavior changes hide in that part of the diff.

## Scope note

This branch touches slightly more than #325/PR #337's original scope. While verifying `filter_distance_data`'s docstring accuracy, we found and fixed an unused `log` parameter (dead since the function's original commit, unrelated to #325) — that pulled in `python/solver/model_data.py`, `model_run.py`, `conftest.py`, and `model_data_test.py`, none of which #325 or PR #337 touch. Flagging this explicitly since it's outside the original ticket's boundary, even though it's a small, low-risk change.

## Code changes (behavior, not wording) — table as of this PR

| File | Change | Reason |
|---|---|---|
| `driving_distance_matrix.py` | `get_missing_origins` → `get_origins_with_blank_distances` (rename) | Old name didn't match behavior; new name matches existing "blank distance_m" terminology already used elsewhere in the file |
| `driving_distance_matrix.py` | `resume_from_partial_output` → `identify_unmatched_pairs` (rename, + import/call-site update in `generate_driving_distances_cli.py`) | Old name implied an action ("resume") the function doesn't perform — no I/O beyond a read, no querying, no writing |
| `generate_driving_distances_cli.py` | `--check-bad-locations` CLI flag removed from `build_arg_parser` | Resolves #325's own deferred "keep vs remove" question: no benefit over a normal run, strictly more expensive (always full-county query, never benefits from resume) |
| `generate_driving_distances_cli.py` | `main()`'s `if args.check_bad_locations:` probe-mode branch removed entirely | Direct consequence of removing the flag |
| `generate_driving_distances_cli.py` | `_report_unrouted_origins`'s `output_path` parameter changed from optional (`str \| None = None`) to required (`str`); the `if output_path is None` branch collapsed | Direct consequence of removing check-bad-locations — probe mode was the only caller with no output path |
| `generate_driving_distances_cli.py` | `derive_origins_and_destinations`: origin-extraction loop vectorized (`.iterrows()` over `blocks_gdf` → column ops) | `.iterrows()` is a known-slow anti-pattern; no polymorphism need for this specific loop |
| `generate_driving_distances_cli.py` | `derive_origins_and_destinations`: destination-extraction loop vectorized (`.iterrows()` over `pots_df` → `.str.split(',', expand=True).astype(float)` on the whole `Lat, Lon` column) | Same as the origins loop — `.iterrows()` anti-pattern, no per-row need once the schema was reduced to one combined-column case |
| `generate_driving_distances_cli.py` | `derive_origins_and_destinations`: `_pick_coord_extractor` deleted; separate `Latitude`/`Longitude`-column support removed, destinations parsed only via combined `Lat, Lon` | Verified the two-schema premise was false — no real committed data ever required separate columns |
| `generate_driving_distances_cli.py` | `derive_origins_and_destinations`: malformed-coordinate validation added (comma-count check on `Lat, Lon`) | Re-implements, in vectorized form, validation that existed in the deleted `_pick_coord_extractor.extract_combined` (which raised on `len(parts) != 2`) — not new protection, carried over |
| `generate_driving_distances_cli.py` | `derive_origins_and_destinations`: the explicit "neither schema present" `ValueError` is gone — a missing `Lat, Lon` column now raises a raw `KeyError` instead | Considered and decided that adding error handling back would mean treating this one field differently from every other column read in this function — chose consistency over extra error handling |
| `generate_driving_distances_cli.py` | `_origin_lines`'s default value: `locations.get(origin, (None, None))` → `locations.get(origin, [None, None])` (tuple→list) | No behavioral change, just cleanup to keep types consistent |
| `model_data.py` / `model_run.py` | `filter_distance_data`'s `log` parameter removed from the signature; call sites updated | Verified via git history it's been unused since the function's original commit (Dec 2025) — dead parameter, not a recent regression |

## Test reorganization — `generate_driving_distances_cli_test.py`

**Before:**

| Class | Tests |
|---|---|
| `TestArgParser` | `test_requires_location_config`, `test_parses_location_config`, `test_default_logdir`, `test_state_defaults_to_none`, `test_explicit_state_flag`, `test_server_and_logdir_overrides` |
| `TestWriteOutputCsv` | `test_writes_only_three_columns_in_order` |
| `TestDeriveOriginsAndDestinations` | `test_handles_combined_lat_lon_column`, `test_raises_when_no_coord_columns` |
| `TestMain` | `test_writes_csv_at_expected_path`, `test_write_path_exits_nonzero_but_still_writes_partial_csv`, `test_resume_skips_pairs_already_in_output`, `test_resume_short_circuits_when_nothing_remains`, `test_short_circuit_exits_nonzero_on_blank_distance_row` |
| `TestStateValidation` | `test_rejects_unknown_state_slug`, `test_state_flag_no_longer_required_on_cli` |
| `TestConfigDerivedState` | `test_derives_state_from_config_location_when_no_flag`, `test_explicit_state_flag_overrides_config_derivation`, `test_errors_when_neither_flag_nor_derivable_location` |
| `TestInContainerHealthCheck` | `test_exits_when_ors_unreachable` |

**After:**

| Class | Tests | Notes |
|---|---|---|
| `TestArgParser` / `TestWriteOutputCsv` / `TestDeriveOriginsAndDestinations` / `TestInContainerHealthCheck` | unchanged | |
| `TestMain` | `test_writes_csv_at_expected_path` | Narrowed to match its own "smoke-test the happy path" docstring |
| `TestResumeBehavior` *(new)* | `test_resume_skips_pairs_already_in_output`, `test_resume_short_circuits_when_nothing_remains` | Pure resume/partial-fetch mechanics |
| `TestUnroutedOriginReporting` *(new)* | `test_write_path_exits_nonzero_but_still_writes_partial_csv`, `test_short_circuit_exits_nonzero_on_blank_distance_row` | Both verify `_report_unrouted_origins` firing + exit 1 + partial data kept — grouped by what's verified, not which branch triggers it |
| `TestStateResolution` *(merged)* | `test_derives_state_from_config_location_when_no_flag`, `test_errors_when_neither_flag_nor_derivable_location`, `test_rejects_unknown_state_slug`, `test_explicit_state_flag_overrides_config_derivation` | Merges `TestStateValidation` + `TestConfigDerivedState`. Dropped `test_state_flag_no_longer_required_on_cli` (verified exact duplicate of `TestArgParser::test_state_defaults_to_none`). Kept the override test — its deletion belongs with #350's implementation, not this PR. |

## Follow-ups filed, not in this PR

- **#350** — replace `--state <slug>`'s free-text override with a `--testing` boolean. The "operators may legitimately point at a different state's graph" justification (encoded in `test_explicit_state_flag_overrides_config_derivation`, kept in this PR) was checked directly and doesn't hold up.
- The two dead `--check-bad-locations` tests are already removed as part of this PR; a stale dual-schema test (`test_returns_locations_dict_and_id_lists`) was also removed after confirming its unique coverage (source-side coordinate extraction) was folded into `test_handles_combined_lat_lon_column` first.
- One known open item: a missing `Lat, Lon` column now raises a raw `KeyError` instead of a clear message (see code-change table above) — deliberate per the reason given, flagging in case reviewers disagree with that call.